### PR TITLE
Auto-fill tool info and streamline operator form

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -25,3 +25,19 @@ export const addToolChange = async (payload) => {
   if (error) throw error
   return data
 }
+
+export const getToolInventory = async () => {
+  const { data, error } = await supabase
+    .from('tool_inventory')
+    .select('tool_id, description, tool_type, insert_type, insert_grade')
+  if (error) throw error
+  return data
+}
+
+export const getEquipment = async () => {
+  const { data, error } = await supabase
+    .from('equipment')
+    .select('number, description, type, work_center')
+  if (error) throw error
+  return data
+}


### PR DESCRIPTION
## Summary
- fetch equipment and tool inventory from Supabase to auto-populate tool change form
- auto-fill work center and insert details when selecting equipment and tool IDs
- drop throughput and quality detail inputs, leaving a simplified operator-facing form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3b6a5864832aa0f0ca1cd351a234