### PR TITLE
feat: expand dashboard analytics

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -99,3 +99,58 @@ export const getEquipment = async (workCenter = null) => {
     return [];
   }
 }
+
+export const getRealTimeToolStatus = async () => {
+  const { data, error } = await supabase
+    .from('tool_changes')
+    .select('machine_number, tool_type, change_reason, date, time')
+    .order('date', { ascending: false })
+    .order('time', { ascending: false })
+  if (error) throw error
+  const latest = {}
+  for (const row of data || []) {
+    if (!latest[row.machine_number]) {
+      latest[row.machine_number] = row
+    }
+  }
+  return Object.values(latest)
+}
+
+export const getCostAnalysis = async () => {
+  const [{ data: changes, error: chErr }, { data: costs, error: costErr }] =
+    await Promise.all([
+      supabase.from('tool_changes').select('tool_type'),
+      supabase.from('tool_costs').select('tool_type, cost_per_tool'),
+    ])
+  if (chErr) throw chErr
+  if (costErr) throw costErr
+  const costMap = {}
+  ;(costs || []).forEach((c) => {
+    costMap[c.tool_type] = parseFloat(c.cost_per_tool) || 0
+  })
+  const analysis = {}
+  ;(changes || []).forEach((ch) => {
+    const cost = costMap[ch.tool_type] || 0
+    analysis[ch.tool_type] = (analysis[ch.tool_type] || 0) + cost
+  })
+  return Object.entries(analysis).map(([tool_type, total_cost]) => ({
+    tool_type,
+    total_cost,
+  }))
+}
+
+export const getToolChangeCorrelation = async () => {
+  const { data, error } = await supabase
+    .from('tool_changes')
+    .select('tool_type, pieces_produced')
+  if (error) throw error
+  const grouped = {}
+  ;(data || []).forEach((ch) => {
+    grouped[ch.tool_type] = (grouped[ch.tool_type] || 0) +
+      (ch.pieces_produced || 0)
+  })
+  return Object.entries(grouped).map(([tool_type, pieces]) => ({
+    tool_type,
+    pieces,
+  }))
+}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,12 +1,47 @@
 import { useEffect, useState } from 'react'
-import { getToolChanges } from '../lib/supabase'
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import {
+  getToolChanges,
+  getRealTimeToolStatus,
+  getCostAnalysis,
+  getToolChangeCorrelation,
+} from '../lib/supabase'
+import { predictToolLife } from '../lib/analytics'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+} from 'recharts'
 
 export default function Dashboard() {
   const [data, setData] = useState([])
+  const [statusData, setStatusData] = useState([])
+  const [costData, setCostData] = useState([])
+  const [correlationData, setCorrelationData] = useState([])
+  const [prediction, setPrediction] = useState(null)
 
   useEffect(() => {
-    getToolChanges().then(setData).catch(console.error)
+    const load = async () => {
+      const changes = await getToolChanges()
+      setData(changes)
+      setStatusData(await getRealTimeToolStatus())
+      setCostData(await getCostAnalysis())
+      setCorrelationData(await getToolChangeCorrelation())
+      if (changes.length > 0) {
+        setPrediction(
+          predictToolLife(
+            changes[0].tool_type,
+            changes[0].insert_type,
+            changes
+          )
+        )
+      }
+    }
+    load().catch(console.error)
   }, [])
 
   const chartData = data.map((item) => ({
@@ -15,18 +50,91 @@ export default function Dashboard() {
   }))
 
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-8">
       <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-      <div className="w-full h-64">
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chartData}>
-            <XAxis dataKey="date" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="pieces" stroke="#2563eb" />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">
+          Real-Time Tool Status by Machine
+        </h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr>
+                <th className="p-2 text-left">Machine</th>
+                <th className="p-2 text-left">Tool</th>
+                <th className="p-2 text-left">Change Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {statusData.map((row) => (
+                <tr key={row.machine_number}>
+                  <td className="p-2">{row.machine_number}</td>
+                  <td className="p-2">{row.tool_type}</td>
+                  <td className="p-2">{row.change_reason || 'N/A'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Insert Performance Trending</h2>
+        <div className="w-full h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData}>
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="pieces" stroke="#2563eb" />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Cost Analysis by Tool Type</h2>
+        <div className="w-full h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={costData}>
+              <XAxis dataKey="tool_type" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="total_cost" fill="#16a34a" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">
+          Correlation with Tool Changes
+        </h2>
+        <div className="w-full h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={correlationData}>
+              <XAxis dataKey="tool_type" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="pieces" fill="#f59e0b" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+
+      {prediction && (
+        <section>
+          <h2 className="text-xl font-semibold mb-2">
+            Predictive Maintenance Indicators
+          </h2>
+          <p className="text-sm">
+            Predicted life: {prediction.predictedLife} pieces ({prediction.confidence}
+            {' '}
+            confidence). Recommendation: {prediction.recommendation}.
+          </p>
+        </section>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- display real-time tool status by machine with table
- add multiple analytics charts: performance trending, cost analysis by tool type, correlation with tool changes
- surface predictive maintenance indicators using historical data

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bedd3b1458832ab8f4e0551b769cda