### PR TITLE
Add operator support and analytics

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -6,62 +6,163 @@ const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
-// Updated addToolChange function to handle new fields
-export async function addToolChange(toolChangeData) {
+// Get all active operators
+export async function getOperators() {
   try {
-    console.log('🔄 Adding tool change to database:', toolChangeData);
-    
+    console.log('🔍 Fetching operators from database...')
+
     const { data, error } = await supabase
-      .from('tool_changes')
-      .insert([{
-        // Basic information
-        date: toolChangeData.date,
-        time: toolChangeData.time,
-        shift: toolChangeData.shift,
-        operator: toolChangeData.operator,
-        // supervisor field removed per requirements
-        
-        // Equipment and operation
-        work_center: toolChangeData.work_center,
-        equipment_number: toolChangeData.equipment_number,
-        operation: toolChangeData.operation,
-        part_number: toolChangeData.part_number,
-        job_number: toolChangeData.job_number,
-        
-        // Tool information - updated structure
-        old_tool_id: toolChangeData.old_tool_id,
-        new_tool_id: toolChangeData.new_tool_id,
-        tool_position: toolChangeData.tool_position,
-        first_rougher: toolChangeData.first_rougher,    // New field
-        finish_tool: toolChangeData.finish_tool,        // New field
-        insert_type: toolChangeData.insert_type,
-        insert_grade: toolChangeData.insert_grade,
-        // tool_type field removed per requirements
-        
-        // Change details
-        change_reason: toolChangeData.change_reason,
-        old_tool_condition: toolChangeData.old_tool_condition,
-        pieces_produced: toolChangeData.pieces_produced,
-        cycle_time_before: toolChangeData.cycle_time_before,
-        cycle_time_after: toolChangeData.cycle_time_after,
-        downtime_minutes: toolChangeData.downtime_minutes,
-        notes: toolChangeData.notes,
-        
-        // Timestamp
-        created_at: toolChangeData.created_at || new Date().toISOString()
-      }])
-      .select();
+      .from('operators')
+      .select(`
+        id,
+        employee_id,
+        clock_number,
+        first_name,
+        last_name,
+        full_name,
+        department,
+        primary_shift,
+        job_title,
+        skill_level,
+        cnc_certified,
+        lathe_certified,
+        mill_certified,
+        cat536_6763_experience,
+        cat536_6763_pieces_produced
+      `)
+      .eq('active', true)
+      .order('full_name')
 
     if (error) {
-      console.error('❌ Supabase error:', error);
-      throw error;
+      console.error('❌ Supabase error fetching operators:', error)
+      throw error
     }
 
-    console.log('✅ Tool change added successfully:', data);
-    return data;
+    console.log('✅ Operators data fetched:', data?.length || 0, 'operators')
+    return data || []
   } catch (error) {
-    console.error('❌ Error in addToolChange:', error);
-    throw error;
+    console.error('❌ Error in getOperators:', error)
+    return []
+  }
+}
+
+// Get operators with CAT536-6763 experience (for specific part tracking)
+export async function getCAT536Operators() {
+  try {
+    const { data, error } = await supabase
+      .from('operators')
+      .select('*')
+      .eq('active', true)
+      .eq('cat536_6763_experience', true)
+      .order('cat536_6763_pieces_produced', { ascending: false })
+
+    if (error) throw error
+    return data || []
+  } catch (error) {
+    console.error('❌ Error fetching CAT536 operators:', error)
+    return []
+  }
+}
+
+// Get operator by employee ID or clock number
+export async function getOperatorById(identifier) {
+  try {
+    let query = supabase.from('operators').select('*').eq('active', true)
+
+    // Check if identifier is numeric (clock number) or alphanumeric (employee ID)
+    if (!isNaN(identifier)) {
+      query = query.eq('clock_number', parseInt(identifier))
+    } else {
+      query = query.eq('employee_id', identifier)
+    }
+
+    const { data, error } = await query.single()
+
+    if (error) throw error
+    return data
+  } catch (error) {
+    console.error('❌ Error fetching operator by ID:', error)
+    return null
+  }
+}
+
+// Updated addToolChange function to include operator linking
+export async function addToolChange(toolChangeData) {
+  try {
+    console.log('🔄 Adding tool change to database:', toolChangeData)
+
+    // If operator info is provided, try to link to operator ID
+    let operatorId = null
+    if (toolChangeData.operator_employee_id || toolChangeData.operator_clock_number) {
+      const operator = await getOperatorById(
+        toolChangeData.operator_employee_id || toolChangeData.operator_clock_number
+      )
+      if (operator) {
+        operatorId = operator.id
+
+        // Update operator's tool change count and last activity
+        await supabase
+          .from('operators')
+          .update({
+            total_tool_changes: operator.total_tool_changes + 1,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', operator.id)
+      }
+    }
+
+    const { data, error } = await supabase
+      .from('tool_changes')
+      .insert([
+        {
+          // Basic information
+          date: toolChangeData.date,
+          time: toolChangeData.time,
+          shift: toolChangeData.shift,
+          operator: toolChangeData.operator,
+          operator_id: operatorId, // Link to operators table
+
+          // Equipment and operation
+          work_center: toolChangeData.work_center,
+          equipment_number: toolChangeData.equipment_number,
+          operation: toolChangeData.operation,
+          part_number: toolChangeData.part_number,
+          job_number: toolChangeData.job_number,
+
+          // Tool information - updated structure
+          old_tool_id: toolChangeData.old_tool_id,
+          new_tool_id: toolChangeData.new_tool_id,
+          tool_position: toolChangeData.tool_position,
+          first_rougher: toolChangeData.first_rougher,
+          finish_tool: toolChangeData.finish_tool,
+          insert_type: toolChangeData.insert_type,
+          insert_grade: toolChangeData.insert_grade,
+
+          // Change details
+          change_reason: toolChangeData.change_reason,
+          old_tool_condition: toolChangeData.old_tool_condition,
+          pieces_produced: toolChangeData.pieces_produced,
+          cycle_time_before: toolChangeData.cycle_time_before,
+          cycle_time_after: toolChangeData.cycle_time_after,
+          downtime_minutes: toolChangeData.downtime_minutes,
+          notes: toolChangeData.notes,
+
+          // Timestamp
+          created_at: toolChangeData.created_at || new Date().toISOString(),
+        },
+      ])
+      .select()
+
+    if (error) {
+      console.error('❌ Supabase error:', error)
+      throw error
+    }
+
+    console.log('✅ Tool change added successfully:', data)
+    return data
+  } catch (error) {
+    console.error('❌ Error in addToolChange:', error)
+    throw error
   }
 }
 
@@ -87,6 +188,39 @@ export async function getToolChanges() {
     return data;
   } catch (error) {
     console.error('❌ Error in getToolChanges:', error);
+    throw error;
+  }
+}
+
+// Get enhanced tool changes with operator details
+export async function getToolChangesWithOperators() {
+  try {
+    const { data, error } = await supabase
+      .from('tool_changes')
+      .select(`
+        *,
+        operator_details:operator_id (
+          employee_id,
+          clock_number,
+          full_name,
+          skill_level,
+          cat536_6763_experience
+        ),
+        equipment:equipment_number (
+          description,
+          work_center
+        )
+      `)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('❌ Error fetching tool changes with operators:', error);
+      throw error;
+    }
+
+    return data;
+  } catch (error) {
+    console.error('❌ Error in getToolChangesWithOperators:', error);
     throw error;
   }
 }
@@ -360,6 +494,83 @@ export async function getToolCostAnalysis(dateRange = 30) {
     };
   } catch (error) {
     console.error('❌ Error in getToolCostAnalysis:', error);
+    throw error;
+  }
+}
+
+// Get operator performance analytics
+export async function getOperatorPerformanceAnalytics(dateRange = 30) {
+  try {
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - dateRange);
+
+    const { data, error } = await supabase
+      .from('tool_changes')
+      .select(`
+        operator,
+        operator_id,
+        pieces_produced,
+        downtime_minutes,
+        cycle_time_before,
+        cycle_time_after,
+        change_reason,
+        date,
+        operator_details:operator_id (
+          employee_id,
+          full_name,
+          skill_level,
+          cat536_6763_pieces_produced
+        )
+      `)
+      .gte('date', startDate.toISOString().split('T')[0])
+      .order('date', { ascending: false });
+
+    if (error) throw error;
+
+    // Process the data to create performance metrics
+    const operatorStats = {};
+
+    data.forEach(change => {
+      const operatorKey = change.operator_details?.employee_id || change.operator || 'Unknown';
+
+      if (!operatorStats[operatorKey]) {
+        operatorStats[operatorKey] = {
+          name: change.operator_details?.full_name || change.operator,
+          skill_level: change.operator_details?.skill_level || 'Unknown',
+          cat536_experience: change.operator_details?.cat536_6763_pieces_produced || 0,
+          tool_changes: 0,
+          total_pieces: 0,
+          total_downtime: 0,
+          avg_cycle_improvement: 0,
+          cycle_improvements: []
+        };
+      }
+
+      const stats = operatorStats[operatorKey];
+      stats.tool_changes++;
+      stats.total_pieces += change.pieces_produced || 0;
+      stats.total_downtime += change.downtime_minutes || 0;
+
+      // Calculate cycle time improvement
+      if (change.cycle_time_before && change.cycle_time_after) {
+        const improvement = change.cycle_time_before - change.cycle_time_after;
+        stats.cycle_improvements.push(improvement);
+      }
+    });
+
+    // Calculate averages
+    Object.values(operatorStats).forEach(stats => {
+      stats.avg_pieces_per_change = stats.tool_changes > 0 ?
+        Math.round(stats.total_pieces / stats.tool_changes) : 0;
+      stats.avg_downtime_per_change = stats.tool_changes > 0 ?
+        Math.round(stats.total_downtime / stats.tool_changes) : 0;
+      stats.avg_cycle_improvement = stats.cycle_improvements.length > 0 ?
+        stats.cycle_improvements.reduce((a, b) => a + b, 0) / stats.cycle_improvements.length : 0;
+    });
+
+    return operatorStats;
+  } catch (error) {
+    console.error('❌ Error in getOperatorPerformanceAnalytics:', error);
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
- Add operator retrieval and analytics helpers in Supabase layer
- Link tool changes to operators and track performance metrics
- Enhance tool change form with dynamic operator dropdown and validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e07915b8832aaf75e41cd92a9ec3