### PR TITLE
Move quick stats to dashboard and remove dashboard links

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -26,13 +26,13 @@ import {
   TrendingUp,
   DollarSign,
   Settings,
-  AlertTriangle,
-  CheckCircle,
   Clock,
   Users,
   Wrench,
   ArrowLeft,
-  RefreshCw
+  RefreshCw,
+  Database,
+  BarChart3
 } from 'lucide-react'
 
 export default function Dashboard() {
@@ -192,6 +192,49 @@ export default function Dashboard() {
       </header>
 
       <div className="max-w-7xl mx-auto px-4 py-8 space-y-8">
+        {/* Quick Stats Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+          <div className="bg-white p-6 rounded-lg shadow-sm border">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-600">Tool Changes Today</p>
+                <p className="text-2xl font-bold text-gray-900">--</p>
+              </div>
+              <TrendingUp className="h-8 w-8 text-blue-600" />
+            </div>
+          </div>
+
+          <div className="bg-white p-6 rounded-lg shadow-sm border">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-600">Active Machines</p>
+                <p className="text-2xl font-bold text-gray-900">--</p>
+              </div>
+              <Settings className="h-8 w-8 text-green-600" />
+            </div>
+          </div>
+
+          <div className="bg-white p-6 rounded-lg shadow-sm border">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-600">Cost Savings</p>
+                <p className="text-2xl font-bold text-gray-900">$--</p>
+              </div>
+              <Database className="h-8 w-8 text-purple-600" />
+            </div>
+          </div>
+
+          <div className="bg-white p-6 rounded-lg shadow-sm border">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-600">Efficiency</p>
+                <p className="text-2xl font-bold text-gray-900">--%</p>
+              </div>
+              <BarChart3 className="h-8 w-8 text-orange-600" />
+            </div>
+          </div>
+        </div>
+
         {/* Key Metrics Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <div className="bg-white p-6 rounded-lg shadow-sm border">

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,6 @@
 import ToolChangeForm from '../components/ToolChangeForm'
 import Link from 'next/link'
-import { BarChart3, Plus, QrCode, Settings, TrendingUp, Database } from 'lucide-react'
+import { Plus, QrCode } from 'lucide-react'
 
 export default function Home() {
   return (
@@ -11,15 +11,8 @@ export default function Home() {
           <div className="flex justify-between items-center">
             <h1 className="text-3xl font-bold text-gray-900">🔧 Tool Change Tracker</h1>
             <nav className="flex space-x-4">
-              <Link 
-                href="/dashboard" 
-                className="flex items-center space-x-2 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
-              >
-                <BarChart3 size={20} />
-                <span>Dashboard & Analytics</span>
-              </Link>
-              <Link 
-                href="/qr-generator" 
+              <Link
+                href="/qr-generator"
                 className="flex items-center space-x-2 bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors"
               >
                 <QrCode size={20} />
@@ -29,65 +22,9 @@ export default function Home() {
           </div>
         </div>
       </header>
-
-      {/* Quick Stats Cards */}
       <div className="max-w-7xl mx-auto px-4 py-8">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium text-gray-600">Tool Changes Today</p>
-                <p className="text-2xl font-bold text-gray-900">--</p>
-              </div>
-              <TrendingUp className="h-8 w-8 text-blue-600" />
-            </div>
-          </div>
-          
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium text-gray-600">Active Machines</p>
-                <p className="text-2xl font-bold text-gray-900">--</p>
-              </div>
-              <Settings className="h-8 w-8 text-green-600" />
-            </div>
-          </div>
-          
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium text-gray-600">Cost Savings</p>
-                <p className="text-2xl font-bold text-gray-900">$--</p>
-              </div>
-              <Database className="h-8 w-8 text-purple-600" />
-            </div>
-          </div>
-          
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium text-gray-600">Efficiency</p>
-                <p className="text-2xl font-bold text-gray-900">--%</p>
-              </div>
-              <BarChart3 className="h-8 w-8 text-orange-600" />
-            </div>
-          </div>
-        </div>
-
         {/* Action Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-          <Link href="/dashboard" className="group">
-            <div className="bg-gradient-to-r from-blue-500 to-blue-600 p-6 rounded-lg text-white hover:from-blue-600 hover:to-blue-700 transition-all transform group-hover:scale-105">
-              <div className="flex items-center space-x-3">
-                <BarChart3 size={32} />
-                <div>
-                  <h3 className="text-xl font-semibold">View Dashboard</h3>
-                  <p className="text-blue-100">Real-time analytics & metrics</p>
-                </div>
-              </div>
-            </div>
-          </Link>
-          
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
           <div className="bg-gradient-to-r from-green-500 to-green-600 p-6 rounded-lg text-white">
             <div className="flex items-center space-x-3">
               <Plus size={32} />
@@ -97,7 +34,7 @@ export default function Home() {
               </div>
             </div>
           </div>
-          
+
           <Link href="/qr-generator" className="group">
             <div className="bg-gradient-to-r from-purple-500 to-purple-600 p-6 rounded-lg text-white hover:from-purple-600 hover:to-purple-700 transition-all transform group-hover:scale-105">
               <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- remove quick stats and dashboard links from the home page
- add quick stats cards to the dashboard page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c23ebef600832ab4788d7ca07b638e