### PR TITLE
Add per-tool change reasons and relocate heat number

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ CREATE TABLE tool_changes (
   tool_position VARCHAR(50),
   insert_type VARCHAR(50),
   insert_grade VARCHAR(50),
+  first_rougher_change_reason VARCHAR(100),
+  finish_tool_change_reason VARCHAR(100),
   change_reason VARCHAR(100),
   old_tool_condition VARCHAR(50),
   pieces_produced INTEGER,

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -139,6 +139,8 @@ export async function addToolChange(toolChangeData) {
           insert_grade: toolChangeData.insert_grade,
 
           // Change details
+          first_rougher_change_reason: toolChangeData.first_rougher_change_reason,
+          finish_tool_change_reason: toolChangeData.finish_tool_change_reason,
           change_reason: toolChangeData.change_reason,
           old_tool_condition: toolChangeData.old_tool_condition,
           pieces_produced: toolChangeData.pieces_produced,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -18,6 +18,8 @@ CREATE TABLE tool_changes (
   tool_position VARCHAR(50),
   insert_type VARCHAR(50),
   insert_grade VARCHAR(50),
+  first_rougher_change_reason VARCHAR(100),
+  finish_tool_change_reason VARCHAR(100),
   change_reason VARCHAR(100),
   old_tool_condition VARCHAR(50),
   pieces_produced INTEGER,


### PR DESCRIPTION
## Summary
- move required heat number into basic information section
- add change reason fields for rougher and finisher replacements
- support new change reason fields in backend schema and insert logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b5c686d8832a8abdc9ef59348cd2