### PR TITLE
Improve Supabase error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ A Next.js and Supabase application for recording and analyzing CNC tool changes.
 2. **Environment variables**
    Create a `.env.local` based on `.env.example` with your Supabase credentials.
 
+   If you encounter authorization errors (HTTP 401) when saving a tool change, double-check that `NEXT_PUBLIC_SUPABASE_URL`
+   and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are set correctly and the keys have the necessary permissions.
+
 3. **Run locally**
    ```bash
    npm run dev

--- a/components/ToolChangeForm.js
+++ b/components/ToolChangeForm.js
@@ -357,7 +357,11 @@ const ToolChangeForm = () => {
       }, 3000);
     } catch (error) {
       console.error('Error saving enhanced tool change:', error);
-      setSubmitStatus('error');
+      if (error?.status === 401 || error?.message?.toLowerCase().includes('401')) {
+        setSubmitStatus('unauthorized');
+      } else {
+        setSubmitStatus('error');
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -427,6 +431,18 @@ const ToolChangeForm = () => {
             <CheckCircle className="h-5 w-5 text-green-600 mr-2" />
             <span className="text-green-800 font-medium">
               Enhanced tool change data saved successfully! Cost: ${costSummary.totalCost.toFixed(2)}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Unauthorized Message */}
+      {submitStatus === 'unauthorized' && (
+        <div className="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex items-center">
+            <AlertTriangle className="h-5 w-5 text-red-600 mr-2" />
+            <span className="text-red-800 font-medium">
+              Authorization failed. Please verify your Supabase credentials.
             </span>
           </div>
         </div>

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -4,6 +4,10 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn('Supabase credentials are missing. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.')
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
 // Get all active operators


### PR DESCRIPTION
## Summary
- warn when Supabase credentials are missing
- surface authorization failures in the tool change form
- document troubleshooting for Supabase 401 errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b8aab1a8832a8ff3b6c852681e64