### PR TITLE
Add missing Package icon import to dashboard

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -32,7 +32,8 @@ import {
   ArrowLeft,
   RefreshCw,
   Database,
-  BarChart3
+  BarChart3,
+  Package
 } from 'lucide-react'
 
 export default function Dashboard() {


### PR DESCRIPTION
## Summary
- import Package icon from `lucide-react` in `pages/dashboard.js`

## Testing
- `npm test`
- `npm run build` *(fails: Supabase credentials are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c608e23720832aa26062fed8bafa59