### PR TITLE
fix: remove equipment join from tool change queries

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -177,13 +177,7 @@ export async function getToolChanges() {
   try {
     const { data, error } = await supabase
       .from('tool_changes')
-      .select(`
-        *,
-        equipment:equipment_number (
-          description,
-          work_center
-        )
-      `)
+      .select('*')
       .order('created_at', { ascending: false });
 
     if (error) {
@@ -211,10 +205,6 @@ export async function getToolChangesWithOperators() {
           full_name,
           skill_level,
           cat536_6763_experience
-        ),
-        equipment:equipment_number (
-          description,
-          work_center
         )
       `)
       .order('created_at', { ascending: false });


### PR DESCRIPTION
## Summary
- remove equipment join from tool change fetches to avoid 400 errors when foreign key is missing

## Testing
- `npm test`
- `npm run build` (fails: Supabase credentials are missing)


------
https://chatgpt.com/codex/tasks/task_e_68c60a5180e8832aa789d85eb9eecbc1