### PR TITLE
Handle missing Supabase insert RPC by falling back to direct insert

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -95,7 +95,6 @@ export async function addToolChange(toolChangeData) {
   try {
     console.log('🔄 Using PostgreSQL function to bypass triggers:', toolChangeData)
 
-    // Use the PostgreSQL function we created
     const { data, error } = await supabase.rpc('insert_tool_change_simple', {
       p_date: toolChangeData.date,
       p_time: toolChangeData.time,
@@ -113,29 +112,142 @@ export async function addToolChange(toolChangeData) {
       p_first_rougher_change_reason: toolChangeData.first_rougher_change_reason || null,
       p_material_appearance: toolChangeData.material_appearance || 'Normal',
       p_notes: toolChangeData.notes || null
-    });
+    })
 
     if (error) {
-      console.error('❌ PostgreSQL function error:', error);
-      throw error;
+      if (isMissingRpcFunctionError(error)) {
+        console.warn('⚠️ PostgreSQL function not available. Falling back to direct insert logic.')
+        return await insertToolChangeDirect(toolChangeData)
+      }
+
+      console.error('❌ PostgreSQL function error:', error)
+      throw error
     }
 
-    console.log('✅ PostgreSQL function insert successful, ID:', data);
-    
-    // Return data in the expected format
+    console.log('✅ PostgreSQL function insert successful, ID:', data)
+
+    if (Array.isArray(data)) {
+      return data
+    }
+
+    const normalizedId =
+      typeof data === 'object' && data !== null && 'id' in data ? data.id : data
+
     return [{
-      id: data,
+      id: normalizedId,
       date: toolChangeData.date,
       time: toolChangeData.time,
       operator: toolChangeData.operator,
       created_at: new Date().toISOString()
-    }];
-
+    }]
   } catch (error) {
-    console.error('❌ Error in addToolChange with PostgreSQL function:', error);
-    console.error('Full error details:', JSON.stringify(error, null, 2));
-    throw error;
+    if (isMissingRpcFunctionError(error)) {
+      console.warn('⚠️ PostgreSQL function missing due to schema mismatch. Using direct insert fallback.')
+      return await insertToolChangeDirect(toolChangeData)
+    }
+
+    console.error('❌ Error in addToolChange with PostgreSQL function:', error)
+    console.error('Full error details:', JSON.stringify(error, null, 2))
+    throw error
   }
+}
+
+function isMissingRpcFunctionError(error) {
+  if (!error) return false
+
+  const message = typeof error === 'string' ? error : error.message || ''
+  const details =
+    typeof error === 'object' && error !== null && 'details' in error ? error.details : ''
+
+  return (
+    error.code === 'PGRST202' ||
+    (typeof message === 'string' && message.includes('Could not find the function')) ||
+    (typeof details === 'string' && details.includes('Could not find the function'))
+  )
+}
+
+async function insertToolChangeDirect(toolChangeData) {
+  console.log('🔁 Executing direct insert fallback for tool change.')
+
+  let operatorId = toolChangeData.operator_id || null
+
+  if (!operatorId && (toolChangeData.operator_employee_id || toolChangeData.operator_clock_number)) {
+    try {
+      const operator = await getOperatorById(
+        toolChangeData.operator_employee_id || toolChangeData.operator_clock_number
+      )
+
+      if (operator?.id) {
+        operatorId = operator.id
+
+        try {
+          await supabase
+            .from('operators')
+            .update({
+              total_tool_changes: (operator.total_tool_changes || 0) + 1,
+              updated_at: new Date().toISOString()
+            })
+            .eq('id', operator.id)
+        } catch (updateError) {
+          console.warn('⚠️ Unable to update operator statistics during fallback insert:', updateError)
+        }
+      }
+    } catch (lookupError) {
+      console.warn('⚠️ Unable to resolve operator details during fallback insert:', lookupError)
+    }
+  }
+
+  const mappedData = {
+    date: toolChangeData.date,
+    time: toolChangeData.time,
+    shift: toolChangeData.shift,
+    operator: toolChangeData.operator,
+    operator_id: operatorId,
+    work_center: toolChangeData.work_center,
+    equipment_number: toolChangeData.equipment_number,
+    operation: toolChangeData.operation,
+    part_number: toolChangeData.part_number,
+    job_number: toolChangeData.job_number,
+    heat_number: toolChangeData.heat_number,
+    old_first_rougher: toolChangeData.old_first_rougher,
+    new_first_rougher: toolChangeData.new_first_rougher,
+    first_rougher_action: toolChangeData.first_rougher_action,
+    old_finish_tool: toolChangeData.old_finish_tool,
+    new_finish_tool: toolChangeData.new_finish_tool,
+    finish_tool_action: toolChangeData.finish_tool_action,
+    first_rougher_change_reason: toolChangeData.first_rougher_change_reason,
+    finish_tool_change_reason: toolChangeData.finish_tool_change_reason,
+    change_reason: toolChangeData.change_reason,
+    material_appearance: toolChangeData.material_appearance,
+    material_risk_score: toolChangeData.material_risk_score,
+    pieces_produced: toolChangeData.pieces_produced,
+    cycle_time_before: toolChangeData.cycle_time_before,
+    cycle_time_after: toolChangeData.cycle_time_after,
+    downtime_minutes: toolChangeData.downtime_minutes,
+    notes: toolChangeData.notes,
+    created_at: toolChangeData.created_at || new Date().toISOString()
+  }
+
+  const cleanData = Object.fromEntries(
+    Object.entries(mappedData).filter(([, value]) =>
+      value !== null && value !== undefined && value !== ''
+    )
+  )
+
+  console.log('📦 Payload for direct insert:', cleanData)
+
+  const { data, error } = await supabase
+    .from('tool_changes')
+    .insert([cleanData])
+    .select()
+
+  if (error) {
+    console.error('❌ Supabase error during direct insert fallback:', error)
+    throw error
+  }
+
+  console.log('✅ Direct insert fallback succeeded:', data)
+  return data
 }
 
 


### PR DESCRIPTION
## Summary
- detect when the insert_tool_change_simple RPC is unavailable and fall back to a direct insert
- reuse the existing insert logic to keep operator updates and column filtering intact
- normalize RPC response handling so callers still receive a consistent result

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c97743336c832a8265dfd5814779b2