### PR TITLE
Handle missing Supabase columns during direct insert fallback

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -166,6 +166,37 @@ function isMissingRpcFunctionError(error) {
   )
 }
 
+function extractMissingColumnFromError(error) {
+  if (!error) return null
+
+  const potentialMessages = []
+
+  if (typeof error === 'string') {
+    potentialMessages.push(error)
+  } else if (typeof error === 'object' && error !== null) {
+    if (typeof error.message === 'string') {
+      potentialMessages.push(error.message)
+    }
+    if (typeof error.details === 'string') {
+      potentialMessages.push(error.details)
+    }
+    if (typeof error.hint === 'string') {
+      potentialMessages.push(error.hint)
+    }
+  }
+
+  for (const text of potentialMessages) {
+    if (typeof text !== 'string') continue
+
+    const match = text.match(/["']([^"']+)["'] column/)
+    if (match?.[1]) {
+      return match[1]
+    }
+  }
+
+  return null
+}
+
 async function insertToolChangeDirect(toolChangeData) {
   console.log('🔁 Executing direct insert fallback for tool change.')
 
@@ -249,20 +280,61 @@ async function insertToolChangeDirect(toolChangeData) {
     )
   )
 
-  console.log('📦 Payload for direct insert:', cleanData)
+  const removedColumns = new Set()
+  let attemptPayload = { ...cleanData }
+  let attemptCount = 0
 
-  const { data, error } = await supabase
-    .from('tool_changes')
-    .insert([cleanData])
-    .select()
+  while (true) {
+    attemptCount += 1
 
-  if (error) {
+    if (attemptCount === 1) {
+      console.log('📦 Payload for direct insert:', attemptPayload)
+    } else {
+      console.log(
+        `📦 Retry payload after removing unsupported columns (${Array.from(removedColumns).join(', ')})`,
+        attemptPayload
+      )
+    }
+
+    const { data, error } = await supabase
+      .from('tool_changes')
+      .insert([attemptPayload])
+      .select()
+
+    if (!error) {
+      if (removedColumns.size > 0) {
+        console.warn(
+          '⚠️ Direct insert fallback succeeded after removing unsupported columns:',
+          Array.from(removedColumns)
+        )
+      }
+      console.log('✅ Direct insert fallback succeeded:', data)
+      return data
+    }
+
+    if (error?.code === 'PGRST204') {
+      const missingColumn = extractMissingColumnFromError(error)
+
+      if (missingColumn && missingColumn in attemptPayload && !removedColumns.has(missingColumn)) {
+        console.warn(
+          `⚠️ Removing unsupported column '${missingColumn}' from payload and retrying insert.`
+        )
+        removedColumns.add(missingColumn)
+        delete attemptPayload[missingColumn]
+
+        if (Object.keys(attemptPayload).length === 0) {
+          throw new Error(
+            'Tool change payload has no supported columns after removing unsupported fields.'
+          )
+        }
+
+        continue
+      }
+    }
+
     console.error('❌ Supabase error during direct insert fallback:', error)
     throw error
   }
-
-  console.log('✅ Direct insert fallback succeeded:', data)
-  return data
 }
 
 


### PR DESCRIPTION
## Summary
- add helper to extract missing column names from Supabase errors
- update the direct insert fallback to retry without unsupported columns so form submissions succeed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c999c1062c832a8ac34e6afc2d3235