### PR TITLE
Update tool change mappings and dashboard display

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -94,113 +94,97 @@ export async function getOperatorById(identifier) {
 
 export async function addToolChange(toolChangeData) {
   try {
-    console.log('Adding tool change to database (trigger disabled):', toolChangeData)
+    console.log('🔧 Adding tool change to database:', toolChangeData)
 
-    // If operator info is provided, try to link to operator ID
-    let operatorId = null
-    if (toolChangeData.operator_employee_id || toolChangeData.operator_clock_number) {
-      const operator = await getOperatorById(
-        toolChangeData.operator_employee_id || toolChangeData.operator_clock_number
-      )
-      if (operator) {
-        operatorId = operator.id
-
-        // Update operator's tool change count
-        await supabase
-          .from('operators')
-          .update({
-            total_tool_changes: (operator.total_tool_changes || 0) + 1,
-            updated_at: new Date().toISOString(),
-          })
-          .eq('id', operator.id)
-      }
-    }
-
-    // Map data to your database schema - using only confirmed existing fields
+    // Map to your actual database schema field names
     const mappedData = {
-      // Basic information
-      date: toolChangeData.date,
-      time: toolChangeData.time,
-      shift: toolChangeData.shift,
-      operator: toolChangeData.operator,
-      operator_id: operatorId,
+      // Basic info - use exact database column names
+      date: toolChangeData.date || new Date().toISOString().split('T')[0],
+      time: toolChangeData.time || new Date().toTimeString().split(' ')[0].slice(0, 5),
+      shift: toolChangeData.shift ? Number(toolChangeData.shift) : null,
 
-      // Equipment and operation
-      work_center: toolChangeData.work_center,
-      equipment_number: toolChangeData.equipment_number,
-      operation: toolChangeData.operation,
-      part_number: toolChangeData.part_number,
-      job_number: toolChangeData.job_number,
-      heat_number: toolChangeData.heat_number,
-      casting_date: toolChangeData.casting_date,
+      // Operator info - use current schema
+      operator: toolChangeData.operator || null,
 
-      // Enhanced tool information - confirmed to exist in your schema
-      old_first_rougher: toolChangeData.old_first_rougher,
-      new_first_rougher: toolChangeData.new_first_rougher,
-      first_rougher_action: toolChangeData.first_rougher_action,
-      old_finish_tool: toolChangeData.old_finish_tool,
-      new_finish_tool: toolChangeData.new_finish_tool,
-      finish_tool_action: toolChangeData.finish_tool_action,
-      old_rougher_material_id: toolChangeData.old_rougher_material_id,
-      new_rougher_material_id: toolChangeData.new_rougher_material_id,
-      old_finish_material_id: toolChangeData.old_finish_material_id,
-      new_finish_material_id: toolChangeData.new_finish_material_id,
-      old_rougher_supplier: toolChangeData.old_rougher_supplier,
-      new_rougher_supplier: toolChangeData.new_rougher_supplier,
-      old_finish_supplier: toolChangeData.old_finish_supplier,
-      new_finish_supplier: toolChangeData.new_finish_supplier,
+      // Equipment - use machine_number (current schema)
+      machine_number: toolChangeData.equipment_number || toolChangeData.machine_number || null,
+      work_center: toolChangeData.work_center || null,
+      operation: toolChangeData.operation || null,
+
+      // Job tracking
+      part_number: toolChangeData.part_number || null,
+      job_number: toolChangeData.job_number || null,
+
+      // Tool data - use current schema field names
+      old_tool_id: toolChangeData.old_first_rougher || toolChangeData.old_finish_tool || null,
+      new_tool_id: toolChangeData.new_first_rougher || toolChangeData.new_finish_tool || null,
+
+      // Map new form fields to current schema
+      first_rougher: toolChangeData.new_first_rougher || null,
+      finish_tool: toolChangeData.new_finish_tool || null,
+
+      insert_type: toolChangeData.insert_type || null,
+      insert_grade: toolChangeData.insert_grade || null,
 
       // Change reasons
-      first_rougher_change_reason: toolChangeData.first_rougher_change_reason,
-      finish_tool_change_reason: toolChangeData.finish_tool_change_reason,
-      change_reason: toolChangeData.change_reason,
+      first_rougher_change_reason: toolChangeData.first_rougher_change_reason || null,
+      finish_tool_change_reason: toolChangeData.finish_tool_change_reason || null,
+      change_reason:
+        toolChangeData.change_reason ||
+        [toolChangeData.first_rougher_change_reason, toolChangeData.finish_tool_change_reason]
+          .filter(Boolean)
+          .join(', ') ||
+        null,
 
-      // Material information
-      material_appearance: toolChangeData.material_appearance,
-      material_risk_score: toolChangeData.material_risk_score,
+      // Performance data
+      pieces_produced: toolChangeData.pieces_produced ? Number(toolChangeData.pieces_produced) : null,
+      cycle_time: toolChangeData.cycle_time || null,
+
+      // Enhanced fields (if you've added the new columns)
+      downtime_minutes: toolChangeData.downtime_minutes ? Number(toolChangeData.downtime_minutes) : null,
+      tool_change_duration_minutes: toolChangeData.tool_change_duration_minutes
+        ? Number(toolChangeData.tool_change_duration_minutes)
+        : null,
+
+      // Quality checks
+      dimension_check: toolChangeData.dimension_check || null,
+      surface_finish: toolChangeData.surface_finish || null,
+
+      // Enhanced tracking (new columns)
+      heat_number: toolChangeData.heat_number || null,
+      material_grade: toolChangeData.material_grade || null,
+      operator_employee_id: toolChangeData.operator_employee_id
+        ? Number(toolChangeData.operator_employee_id)
+        : null,
+      operator_clock_number: toolChangeData.operator_clock_number
+        ? Number(toolChangeData.operator_clock_number)
+        : null,
 
       // Cost tracking
-      rougher_cost: toolChangeData.rougher_cost,
-      finish_cost: toolChangeData.finish_cost,
-      total_tool_cost: toolChangeData.total_tool_cost,
-      cost_per_tool: toolChangeData.cost_per_tool,
+      total_tool_cost: toolChangeData.total_tool_cost || 0,
+      rougher_cost: toolChangeData.rougher_cost || 0,
+      finish_cost: toolChangeData.finish_cost || 0,
 
-      // Performance tracking
-      pieces_produced: toolChangeData.pieces_produced,
-      cycle_time_before: toolChangeData.cycle_time_before,
-      cycle_time_after: toolChangeData.cycle_time_after,
-      downtime_minutes: toolChangeData.downtime_minutes,
-
-      // Notes
-      notes: toolChangeData.notes,
-
-      // Timestamp
-      created_at: toolChangeData.created_at || new Date().toISOString(),
+      // Metadata
+      notes: toolChangeData.notes || null,
+      created_at: new Date().toISOString(),
+      data_source: 'enhanced_form',
+      data_validated: true,
     }
 
-    // Remove null/undefined values
-    const cleanData = Object.fromEntries(
-      Object.entries(mappedData).filter(([_, value]) => 
-        value !== null && value !== undefined && value !== ''
-      )
-    );
+    console.log('📝 Mapped data for database:', mappedData)
 
-    console.log('Clean data for database insert:', cleanData);
-
-    const { data, error } = await supabase
-      .from('tool_changes')
-      .insert([cleanData])
-      .select()
+    const { data, error } = await supabase.from('tool_changes').insert([mappedData]).select()
 
     if (error) {
-      console.error('Supabase error:', error)
+      console.error('❌ Supabase error:', error)
       throw error
     }
 
-    console.log('Tool change added successfully:', data)
+    console.log('✅ Tool change added successfully:', data)
     return data
   } catch (error) {
-    console.error('Error in addToolChange:', error)
+    console.error('❌ Error in addToolChange:', error)
     throw error
   }
 }

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -36,6 +36,193 @@ import {
   Package
 } from 'lucide-react'
 
+const mapToolChangeForDisplay = (toolChange) => {
+  const operatorDisplay =
+    toolChange.operator ||
+    toolChange.operator_details?.full_name ||
+    (toolChange.operator_employee_id ? `Employee ${toolChange.operator_employee_id}` : null) ||
+    'N/A'
+
+  const equipmentDisplay =
+    toolChange.machine_number || toolChange.equipment_number || toolChange.work_center || 'N/A'
+
+  const firstRougherDisplay = toolChange.first_rougher || toolChange.new_tool_id || 'N/A'
+  const finishToolDisplay = toolChange.finish_tool || toolChange.new_tool_id || 'N/A'
+
+  const changeReasonDisplay =
+    toolChange.change_reason ||
+    toolChange.first_rougher_change_reason ||
+    toolChange.finish_tool_change_reason ||
+    'N/A'
+
+  const downtimeValue =
+    toolChange.downtime_minutes ?? toolChange.tool_change_duration_minutes ?? 'N/A'
+
+  const totalCostValue = Number(toolChange.total_tool_cost ?? 0)
+
+  return {
+    id: toolChange.id,
+    date: toolChange.date || 'N/A',
+    time: toolChange.time || 'N/A',
+    operator: operatorDisplay,
+    equipment: equipmentDisplay,
+    firstRougher: firstRougherDisplay,
+    finishTool: finishToolDisplay,
+    changeReason: changeReasonDisplay,
+    downtime: downtimeValue,
+    partNumber: toolChange.part_number || 'N/A',
+    jobNumber: toolChange.job_number || 'N/A',
+    heatNumber: toolChange.heat_number || 'N/A',
+    piecesProduced: toolChange.pieces_produced ?? 'N/A',
+    totalCost: Number.isFinite(totalCostValue) ? totalCostValue : 0,
+    notes: toolChange.notes || '',
+    rawData: toolChange
+  }
+}
+
+const ToolChangesTable = ({ toolChanges = [] }) => {
+  const mappedData = toolChanges.map(mapToolChangeForDisplay)
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border overflow-hidden">
+      <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+        <h3 className="text-lg font-semibold text-gray-900">Recent Tool Changes</h3>
+        <span className="text-sm text-gray-500">{toolChanges.length} records</span>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Date/Time
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Operator
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Equipment
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                1st Rougher
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Finish Tool
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Reason
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Downtime
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Cost
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {mappedData.map((change, index) => (
+              <tr key={change.id || index} className="hover:bg-gray-50">
+                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                  <div>
+                    <div className="font-medium">{change.date}</div>
+                    <div className="text-gray-500">{change.time}</div>
+                  </div>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-sm">
+                  <div className={`font-medium ${change.operator !== 'N/A' ? 'text-gray-900' : 'text-gray-400'}`}>
+                    {change.operator}
+                  </div>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-sm">
+                  <div className={`font-medium ${change.equipment !== 'N/A' ? 'text-gray-900' : 'text-gray-400'}`}>
+                    {change.equipment}
+                  </div>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-sm">
+                  <span
+                    className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                      change.firstRougher !== 'N/A'
+                        ? 'bg-blue-100 text-blue-800'
+                        : 'bg-gray-100 text-gray-500'
+                    }`}
+                  >
+                    {change.firstRougher}
+                  </span>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-sm">
+                  <span
+                    className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                      change.finishTool !== 'N/A'
+                        ? 'bg-green-100 text-green-800'
+                        : 'bg-gray-100 text-gray-500'
+                    }`}
+                  >
+                    {change.finishTool}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-sm text-gray-900 max-w-xs truncate">
+                  {change.changeReason}
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                  {change.downtime !== 'N/A' ? `${change.downtime} min` : 'N/A'}
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                  {change.totalCost > 0 ? `$${change.totalCost.toFixed(2)}` : 'N/A'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {toolChanges.length === 0 && (
+        <div className="text-center py-12 text-gray-500">
+          <div className="text-lg mb-2">No tool changes recorded yet</div>
+          <Link href="/tool-change-form" className="text-blue-600 hover:text-blue-500">
+            Add your first tool change →
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const debugToolChangeData = async () => {
+  try {
+    const changes = await getToolChanges()
+    console.log('=== TOOL CHANGES DEBUG INFO ===')
+    console.log('Total records:', changes?.length || 0)
+
+    if (changes && changes.length > 0) {
+      const latest = changes[0]
+      console.log('Latest record structure:', latest)
+      console.log('Available fields:', Object.keys(latest))
+
+      // Test the mapping function
+      const mapped = mapToolChangeForDisplay(latest)
+      console.log('Mapped display data:', mapped)
+
+      // Check specific fields that were showing N/A
+      console.log('Field check:', {
+        original_operator: latest.operator,
+        original_machine: latest.machine_number,
+        original_equipment: latest.equipment_number,
+        original_first_rougher: latest.first_rougher,
+        original_finish_tool: latest.finish_tool,
+        original_change_reason: latest.change_reason,
+        mapped_operator: mapped.operator,
+        mapped_equipment: mapped.equipment,
+        mapped_firstRougher: mapped.firstRougher,
+        mapped_finishTool: mapped.finishTool,
+        mapped_changeReason: mapped.changeReason
+      })
+    }
+  } catch (error) {
+    console.error('Debug error:', error)
+  }
+}
+
 export default function Dashboard() {
   const [toolChanges, setToolChanges] = useState([])
   const [analytics, setAnalytics] = useState(null)
@@ -53,6 +240,7 @@ export default function Dashboard() {
   const colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#06B6D4']
 
   useEffect(() => {
+    debugToolChangeData()
     loadDashboardData()
   }, [selectedDateRange])
 
@@ -418,52 +606,10 @@ export default function Dashboard() {
         )}
 
         {/* Recent Tool Changes Table */}
-        <div className="bg-white p-6 rounded-lg shadow-sm border">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">Recent Tool Changes</h2>
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date/Time</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Operator</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Equipment</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">1st Rougher</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Finish Tool</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Reason</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Downtime</th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {toolChanges.slice(0, 10).map((change, index) => (
-                  <tr key={index} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {change.date} {change.time}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {change.operator || 'N/A'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {change.equipment_number || 'N/A'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {change.first_rougher || 'N/A'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {change.finish_tool || 'N/A'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {change.change_reason || 'N/A'}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {change.downtime_minutes ? `${change.downtime_minutes} min` : 'N/A'}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <ToolChangesTable toolChanges={toolChanges} />
       </div>
     </div>
   )
 }
+
+export { ToolChangesTable, debugToolChangeData, mapToolChangeForDisplay }


### PR DESCRIPTION
## Summary
- update `addToolChange` to map submitted tool change data into the correct Supabase columns and log the mapped payload
- add a reusable tool change table mapper/component plus a debugging helper to inspect fetched records
- render the dashboard table with the mapped data and trigger the debug logger during dashboard loads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca122536a4832a88987e1f1bd40bdc