### PR TITLE
Handle missing cost_per_tool column in tool change submissions

### DIFF
--- a/components/ToolChangeForm.js
+++ b/components/ToolChangeForm.js
@@ -461,21 +461,6 @@ const ToolChangeForm = () => {
       const oldFinishTool = getToolDetails(formData.old_finish_tool);
       const newFinishTool = getToolDetails(formData.new_finish_tool);
 
-      const replacementCosts = [];
-
-      if (newRougherTool && formData.first_rougher_action === 'Replace') {
-        replacementCosts.push(newRougherTool.unit_cost || 0);
-      }
-
-      if (newFinishTool && formData.finish_tool_action === 'Replace') {
-        replacementCosts.push(newFinishTool.unit_cost || 0);
-      }
-
-      const calculatedCostPerTool =
-        replacementCosts.length > 0
-          ? replacementCosts.reduce((sum, cost) => sum + (Number.isFinite(cost) ? cost : 0), 0)
-          : null;
-
       const cleanedData = {
         date: formData.date,
         time: formData.time,
@@ -521,8 +506,7 @@ const ToolChangeForm = () => {
         old_rougher_supplier: oldRougherTool?.supplier_name || null,
         new_rougher_supplier: newRougherTool?.supplier_name || null,
         old_finish_supplier: oldFinishTool?.supplier_name || null,
-        new_finish_supplier: newFinishTool?.supplier_name || null,
-        cost_per_tool: calculatedCostPerTool
+        new_finish_supplier: newFinishTool?.supplier_name || null
       };
 
       const result = await addToolChange(cleanedData);

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -182,7 +182,6 @@ export async function addToolChange(toolChangeData) {
       rougher_cost: toNumberOrNull(toolChangeData.rougher_cost),
       finish_cost: toNumberOrNull(toolChangeData.finish_cost),
       total_tool_cost: toNumberOrNull(toolChangeData.total_tool_cost),
-      cost_per_tool: toNumberOrNull(toolChangeData.cost_per_tool),
 
       // Metadata
       notes: toolChangeData.notes || null,


### PR DESCRIPTION
## Summary
- remove the cost_per_tool value from tool change submissions to match the current Supabase schema
- simplify the tool change form by no longer calculating an unused per-tool cost

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca2dd72d40832a8bae71f7888e55f4