### PR TITLE
Handle Supabase schema mismatches on tool change insert

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -194,17 +194,49 @@ export async function addToolChange(toolChangeData) {
 
     console.log('📝 Mapped data for database:', sanitizedData)
 
-    const { data, error } = await supabase.from('tool_changes').insert([sanitizedData]).select()
+    const insertResult = await insertToolChangeWithFallback(sanitizedData)
 
-    if (error) {
-      console.error('❌ Supabase error:', error)
-      throw error
-    }
-
-    console.log('✅ Tool change added successfully:', data)
-    return data
+    console.log('✅ Tool change added successfully:', insertResult)
+    return insertResult
   } catch (error) {
     console.error('❌ Error in addToolChange:', error)
+    throw error
+  }
+}
+
+async function insertToolChangeWithFallback(initialData) {
+  let payload = { ...initialData }
+  const removedColumns = new Set()
+
+  while (true) {
+    const { data, error } = await supabase.from('tool_changes').insert([payload]).select()
+
+    if (!error) {
+      if (removedColumns.size > 0) {
+        console.warn(
+          `⚠️ Insert succeeded after removing unsupported columns: ${Array.from(removedColumns).join(', ')}`
+        )
+      }
+      return data
+    }
+
+    const missingColumnMatch =
+      error?.code === 'PGRST204' && typeof error?.message === 'string'
+        ? error.message.match(/'([^']+)' column/)
+        : null
+
+    if (missingColumnMatch) {
+      const missingColumn = missingColumnMatch[1]
+
+      if (missingColumn && Object.prototype.hasOwnProperty.call(payload, missingColumn)) {
+        console.warn(`⚠️ Column '${missingColumn}' not found in schema. Retrying without it...`)
+        delete payload[missingColumn]
+        removedColumns.add(missingColumn)
+        continue
+      }
+    }
+
+    console.error('❌ Supabase error:', error)
     throw error
   }
 }


### PR DESCRIPTION
## Summary
- add a fallback insert helper that retries without unsupported columns when Supabase reports schema cache mismatches
- log successful inserts and removed columns to aid troubleshooting of differing deployments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca2faaeaf8832ab4dfa1ddf9831a26