### PR TITLE
Improve dynamic blast exit template handling

### DIFF
--- a/pages/blast-exit.js
+++ b/pages/blast-exit.js
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
 import Head from 'next/head'
+import { supabase } from '../lib/supabase'
 
 const statusStyles = {
   NONE: {
-    input: 'border-amber-200 bg-white',
-    badge: 'text-gray-500',
-    indicator: 'bg-gray-300',
+    input: 'border-slate-200 bg-white',
+    badge: 'text-slate-500',
+    indicator: 'bg-slate-300',
     label: 'Awaiting Measurement'
   },
   PASS: {
@@ -30,90 +31,7 @@ const statusStyles = {
 
 const cylinderFields = ['barrelDiameter', 'flangeDiameter', 'overallLength', 'lengthToFlange']
 
-const productSpecs = {
-  'CAT536-6765': {
-    type: 'cylinder',
-    productFamily: '536_SERIES',
-    info: 'Highest priority cylinder. Use measurement sheet 41A2360.',
-    barrelTarget: 11.569,
-    barrelTol: 0.02,
-    flangeTarget: 12.87,
-    flangeTol: 0.02,
-    lengthTarget: 59.519,
-    lengthTol: 0.02,
-    flangeToTarget: 54.622,
-    flangeToTol: 0.02
-  },
-  'CAT536-6763': {
-    type: 'cylinder',
-    productFamily: '536_SERIES',
-    info: 'High priority cylinder. Similar to 6765 procedures.',
-    barrelTarget: 11.5,
-    barrelTol: 0.02,
-    flangeTarget: 12.8,
-    flangeTol: 0.02,
-    lengthTarget: 58,
-    lengthTol: 0.02,
-    flangeToTarget: 53,
-    flangeToTol: 0.02
-  },
-  'CAT536-6764': {
-    type: 'cylinder',
-    productFamily: '536_SERIES',
-    info: 'High priority cylinder. Part of 536 family.',
-    barrelTarget: 11.4,
-    barrelTol: 0.02,
-    flangeTarget: 12.7,
-    flangeTol: 0.02,
-    lengthTarget: 57.5,
-    lengthTol: 0.02,
-    flangeToTarget: 52.5,
-    flangeToTol: 0.02
-  },
-  'CAT150-3014': {
-    type: 'large_casting',
-    productFamily: 'LARGE_SERIES',
-    info: 'Large casting. Use standard measurement procedures for large components.'
-  },
-  'CAT150-3011': {
-    type: 'large_casting',
-    productFamily: 'LARGE_SERIES',
-    info: 'Large casting ~1450 lbs. High scrap cost - verify all dimensions carefully.',
-    lengthTarget: 60,
-    lengthTol: 0.04
-  },
-  'CAT4T-6051': {
-    type: 'heavy_duty',
-    productFamily: '4T_SERIES',
-    info: 'Heavy duty casting. Multiple OD measurements required. Focus on machining surfaces.',
-    lengthTarget: 45,
-    lengthTol: 0.03
-  },
-  'CAT4T-5937': {
-    type: 'heavy_duty',
-    productFamily: '4T_SERIES',
-    info: 'Heavy duty casting. Check structural integrity and multiple OD locations.',
-    lengthTarget: 42,
-    lengthTol: 0.03
-  },
-  'CAT4T-4774': {
-    type: 'heavy_duty',
-    productFamily: '4T_SERIES',
-    info: 'Heavy duty casting. Medium priority component.'
-  },
-  'CAT121-2077': {
-    type: 'large_assembly',
-    productFamily: 'LARGE_SERIES',
-    info: 'Large assembly. Follow standard measurement procedures.'
-  },
-  'CAT522-7552': {
-    type: 'large_assembly',
-    productFamily: 'LARGE_SERIES',
-    info: 'Large assembly. Ensure all dimensions are recorded accurately.'
-  }
-}
-
-const initialFormData = {
+const createInitialFormData = () => ({
   productNumber: '',
   heatNumber: '',
   trackingNumber: '',
@@ -123,108 +41,213 @@ const initialFormData = {
   flangeDiameter: '',
   overallLength: '',
   lengthToFlange: '',
-  od1: '',
-  od2: '',
-  od3: '',
-  id1: '',
-  id2: '',
-  length1: '',
   materialAppearance: '',
   dimensionalStatus: 'PASS',
   heatTreatApproved: 'true',
   surfaceCondition: '',
-  notes: ''
-}
+  notes: '',
+  odMeasurements: [],
+  idMeasurements: [],
+  lengthMeasurements: []
+})
 
 const initialToleranceStatuses = cylinderFields.reduce((accumulator, key) => {
   return { ...accumulator, [key]: 'NONE' }
 }, {})
 
-function evaluateTolerance(value, { target, tolerance }) {
+function evaluateTolerance(value, target, tolerance) {
   const numericValue = parseFloat(value)
+  const numericTarget = parseFloat(target)
+  const numericTolerance = parseFloat(tolerance)
 
-  if (!Number.isFinite(numericValue)) {
+  if (!Number.isFinite(numericValue) || !Number.isFinite(numericTarget) || !Number.isFinite(numericTolerance)) {
     return 'NONE'
   }
 
-  const deviation = Math.abs(numericValue - target)
+  const deviation = Math.abs(numericValue - numericTarget)
 
-  if (deviation <= tolerance) {
+  if (deviation <= numericTolerance) {
     return 'PASS'
   }
 
-  if (deviation <= tolerance * 1.5) {
+  if (deviation <= numericTolerance * 1.5) {
     return 'MARGINAL'
   }
 
   return 'FAIL'
 }
 
+function getTolerance(value, fallback) {
+  const numericValue = parseFloat(value)
+  return Number.isFinite(numericValue) ? numericValue : fallback
+}
+
+function normalizeNumber(value) {
+  const numericValue = parseFloat(value)
+  return Number.isFinite(numericValue) ? numericValue : null
+}
+
+function sanitizeCount(value) {
+  const numericValue = Number.parseInt(value, 10)
+
+  if (!Number.isFinite(numericValue)) {
+    return 0
+  }
+
+  return Math.max(0, numericValue)
+}
+
 export default function BlastExitMeasurement() {
-  const [formData, setFormData] = useState(() => ({ ...initialFormData }))
+  const [formData, setFormData] = useState(() => createInitialFormData())
   const [toleranceStatuses, setToleranceStatuses] = useState(() => ({ ...initialToleranceStatuses }))
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [successMessage, setSuccessMessage] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
+  const [templates, setTemplates] = useState([])
+  const [loadingTemplates, setLoadingTemplates] = useState(true)
+  const [loadingError, setLoadingError] = useState('')
 
-  const selectedSpec = formData.productNumber ? productSpecs[formData.productNumber] : null
-  const isCylinder = selectedSpec?.type === 'cylinder'
-  const showGenericMeasurements = Boolean(formData.productNumber && !isCylinder)
+  useEffect(() => {
+    const loadTemplates = async () => {
+      try {
+        setLoadingTemplates(true)
+        setLoadingError('')
+
+        const { data, error } = await supabase
+          .from('measurement_templates')
+          .select('*')
+          .like('product_number', 'CAT%')
+          .eq('active', true)
+          .order('priority_score', { ascending: false })
+          .order('product_number', { ascending: true })
+
+        if (error) {
+          throw error
+        }
+
+        if (!data || data.length === 0) {
+          throw new Error('No CAT products found in database')
+        }
+
+        setTemplates(data)
+      } catch (error) {
+        console.error('Error loading products:', error)
+        setLoadingError(
+          `Error loading products: ${error.message}. Please verify Supabase credentials, table structure, and CAT templates.`
+        )
+      } finally {
+        setLoadingTemplates(false)
+      }
+    }
+
+    loadTemplates()
+  }, [])
+
+  const templatesByNumber = useMemo(() => {
+    return templates.reduce((accumulator, template) => {
+      accumulator[template.product_number] = template
+      return accumulator
+    }, {})
+  }, [templates])
+
+  const selectedSpec = formData.productNumber ? templatesByNumber[formData.productNumber] : null
+
+  const showBarrelDiameter = Boolean(
+    selectedSpec?.requires_barrel_diameter || normalizeNumber(selectedSpec?.barrel_diameter_target) !== null
+  )
+  const showFlangeDiameter = Boolean(
+    selectedSpec?.requires_flange_diameter || normalizeNumber(selectedSpec?.flange_diameter_target) !== null
+  )
+  const showOverallLength = Boolean(
+    selectedSpec?.requires_overall_length || normalizeNumber(selectedSpec?.overall_length_target) !== null
+  )
+  const showLengthToFlange = Boolean(
+    selectedSpec?.requires_length_to_flange || normalizeNumber(selectedSpec?.length_to_flange_target) !== null
+  )
+
+  const isCylinder = useMemo(() => {
+    if (!selectedSpec) {
+      return false
+    }
+
+    if (selectedSpec.product_family === '536_SERIES') {
+      return true
+    }
+
+    return showBarrelDiameter || showFlangeDiameter || showLengthToFlange
+  }, [selectedSpec, showBarrelDiameter, showFlangeDiameter, showLengthToFlange])
+
+  const odCount = formData.odMeasurements.length
+  const idCount = formData.idMeasurements.length
+  const lengthCount = formData.lengthMeasurements.length
+  const scrapThreshold = normalizeNumber(selectedSpec?.scrap_threshold_percentage)
+  const reworkThreshold = normalizeNumber(selectedSpec?.rework_threshold_percentage)
 
   const toleranceMap = useMemo(() => {
     if (!isCylinder || !selectedSpec) {
       return {}
     }
 
-    return {
-      barrelDiameter: { target: selectedSpec.barrelTarget, tolerance: selectedSpec.barrelTol },
-      flangeDiameter: { target: selectedSpec.flangeTarget, tolerance: selectedSpec.flangeTol },
-      overallLength: { target: selectedSpec.lengthTarget, tolerance: selectedSpec.lengthTol },
-      lengthToFlange: { target: selectedSpec.flangeToTarget, tolerance: selectedSpec.flangeToTol }
-    }
-  }, [isCylinder, selectedSpec])
+    const map = {}
 
-  const cylinderMeasurements = useMemo(() => {
-    if (!isCylinder || !selectedSpec) {
-      return []
-    }
-
-    return [
-      {
-        key: 'barrelDiameter',
-        label: 'Barrel Diameter',
-        target: selectedSpec.barrelTarget,
-        tolerance: selectedSpec.barrelTol
-      },
-      {
-        key: 'flangeDiameter',
-        label: 'Flange Diameter',
-        target: selectedSpec.flangeTarget,
-        tolerance: selectedSpec.flangeTol
-      },
-      {
-        key: 'overallLength',
-        label: 'Overall Length',
-        target: selectedSpec.lengthTarget,
-        tolerance: selectedSpec.lengthTol
-      },
-      {
-        key: 'lengthToFlange',
-        label: 'Length to Flange',
-        target: selectedSpec.flangeToTarget,
-        tolerance: selectedSpec.flangeToTol
+    if (showBarrelDiameter) {
+      const target = normalizeNumber(selectedSpec.barrel_diameter_target)
+      if (target !== null) {
+        map.barrelDiameter = {
+          target,
+          tolerance: getTolerance(selectedSpec.barrel_diameter_tolerance, 0.02)
+        }
       }
-    ]
-  }, [isCylinder, selectedSpec])
+    }
+
+    if (showFlangeDiameter) {
+      const target = normalizeNumber(selectedSpec.flange_diameter_target)
+      if (target !== null) {
+        map.flangeDiameter = {
+          target,
+          tolerance: getTolerance(selectedSpec.flange_diameter_tolerance, 0.02)
+        }
+      }
+    }
+
+    if (showOverallLength) {
+      const target = normalizeNumber(selectedSpec.overall_length_target)
+      if (target !== null) {
+        map.overallLength = {
+          target,
+          tolerance: getTolerance(selectedSpec.overall_length_tolerance, 0.03)
+        }
+      }
+    }
+
+    if (showLengthToFlange) {
+      const target = normalizeNumber(selectedSpec.length_to_flange_target)
+      if (target !== null) {
+        map.lengthToFlange = {
+          target,
+          tolerance: getTolerance(selectedSpec.length_to_flange_tolerance, 0.02)
+        }
+      }
+    }
+
+    return map
+  }, [
+    isCylinder,
+    selectedSpec,
+    showBarrelDiameter,
+    showFlangeDiameter,
+    showLengthToFlange,
+    showOverallLength
+  ])
 
   useEffect(() => {
-    setToleranceStatuses(() => {
-      const updated = { ...initialToleranceStatuses }
+    setToleranceStatuses((previous) => {
+      const updated = { ...previous }
 
       cylinderFields.forEach((field) => {
         const config = toleranceMap[field]
         const value = formData[field]
-        updated[field] = config ? evaluateTolerance(value, config) : 'NONE'
+        updated[field] = config ? evaluateTolerance(value, config.target, config.tolerance) : 'NONE'
       })
 
       return updated
@@ -234,74 +257,92 @@ export default function BlastExitMeasurement() {
   const handleFieldChange = (event) => {
     const { name, value } = event.target
 
+    if (name === 'productNumber') {
+      const template = value && value !== 'OTHER' ? templatesByNumber[value] : null
+
+      const resolvedOdCount = template
+        ? sanitizeCount(template.od_measurement_count)
+        : value === 'OTHER'
+          ? 3
+          : 0
+
+      const resolvedIdCount = template
+        ? sanitizeCount(template.id_measurement_count)
+        : value === 'OTHER'
+          ? 2
+          : 0
+
+      const resolvedLengthCount = template
+        ? sanitizeCount(template.length_measurement_count)
+        : value === 'OTHER'
+          ? 1
+          : 0
+
+      setFormData((previous) => ({
+        ...previous,
+        productNumber: value,
+        barrelDiameter: '',
+        flangeDiameter: '',
+        overallLength: '',
+        lengthToFlange: '',
+        odMeasurements: Array.from({ length: resolvedOdCount }, () => ''),
+        idMeasurements: Array.from({ length: resolvedIdCount }, () => ''),
+        lengthMeasurements: Array.from({ length: resolvedLengthCount }, () => '')
+      }))
+      return
+    }
+
     setFormData((previous) => ({
       ...previous,
       [name]: value
     }))
   }
 
+  const handleMeasurementChange = (field, index, value) => {
+    setFormData((previous) => {
+      const existingMeasurements = previous[field] || []
+      const updatedMeasurements = [...existingMeasurements]
+      updatedMeasurements[index] = value
+      return {
+        ...previous,
+        [field]: updatedMeasurements
+      }
+    })
+  }
+
   const resetFormFields = () => {
-    setFormData({ ...initialFormData })
+    setFormData(createInitialFormData())
     setToleranceStatuses({ ...initialToleranceStatuses })
   }
 
-  const autoFill536 = () => {
+  const quickFillHeat = () => {
     const now = new Date()
     const generatedHeat = `H${now.getTime().toString().slice(-6)}`
 
     setFormData((previous) => ({
       ...previous,
-      productNumber: 'CAT536-6765',
       heatNumber: generatedHeat,
-      operator: 'Test Operator',
-      shift: '1',
-      barrelDiameter: '11.5690',
-      flangeDiameter: '12.8700',
-      overallLength: '59.5190',
-      lengthToFlange: '54.6220',
-      materialAppearance: 'GOOD',
-      dimensionalStatus: 'PASS',
-      heatTreatApproved: 'true'
+      operator: previous.operator || 'Operator',
+      shift: previous.shift || '1'
     }))
   }
 
-  const autoFill4T = () => {
-    const now = new Date()
-    const generatedHeat = `H${now.getTime().toString().slice(-6)}`
-
-    setFormData((previous) => ({
-      ...previous,
-      productNumber: 'CAT4T-6051',
-      heatNumber: generatedHeat,
-      operator: 'Test Operator',
-      shift: '1',
-      od1: '12.5000',
-      od2: '8.7500',
-      od3: '6.2500',
-      length1: '45.0000',
-      materialAppearance: 'GOOD',
-      dimensionalStatus: 'PASS',
-      heatTreatApproved: 'true'
-    }))
+  const loadLastMeasurement = () => {
+    alert('Load last measurement feature coming soon - will pull from recent measurements.')
   }
 
-  const autoFillLarge = () => {
-    const now = new Date()
-    const generatedHeat = `H${now.getTime().toString().slice(-6)}`
+  const showInstructions = () => {
+    if (selectedSpec?.measurement_instructions) {
+      alert(`Measurement Instructions for ${formData.productNumber}:\n\n${selectedSpec.measurement_instructions}`)
+      return
+    }
 
-    setFormData((previous) => ({
-      ...previous,
-      productNumber: 'CAT150-3011',
-      heatNumber: generatedHeat,
-      operator: 'Test Operator',
-      shift: '1',
-      od1: '24.0000',
-      od2: '18.5000',
-      length1: '60.0000',
-      materialAppearance: 'GOOD',
-      dimensionalStatus: 'PASS',
-      heatTreatApproved: 'true'
-    }))
+    if (formData.productNumber) {
+      alert('Standard measurement procedures apply for this product.')
+      return
+    }
+
+    alert('Please select a product first to see specific instructions.')
   }
 
   const handleSubmit = async (event) => {
@@ -311,41 +352,56 @@ export default function BlastExitMeasurement() {
     setSuccessMessage('')
     setErrorMessage('')
 
-    const spec = selectedSpec
-
     const measurementData = {
       heat_number: formData.heatNumber,
       tracking_number: formData.trackingNumber ? parseInt(formData.trackingNumber, 10) : null,
       product_number: formData.productNumber || null,
-      product_family: spec?.productFamily || 'OTHER',
+      product_family: selectedSpec?.product_family || null,
       measurement_date: new Date().toISOString().split('T')[0],
       measurement_time: new Date().toTimeString().split(' ')[0].slice(0, 5),
       operator: formData.operator,
       shift: formData.shift ? parseInt(formData.shift, 10) : null,
       barrel_diameter_actual: formData.barrelDiameter ? parseFloat(formData.barrelDiameter) : null,
-      barrel_diameter_target: spec?.barrelTarget ?? null,
-      barrel_diameter_tolerance: spec?.barrelTol ?? null,
+      barrel_diameter_target: selectedSpec?.barrel_diameter_target ?? null,
+      barrel_diameter_tolerance: selectedSpec?.barrel_diameter_tolerance ?? null,
       flange_diameter_actual: formData.flangeDiameter ? parseFloat(formData.flangeDiameter) : null,
-      flange_diameter_target: spec?.flangeTarget ?? null,
-      flange_diameter_tolerance: spec?.flangeTol ?? null,
+      flange_diameter_target: selectedSpec?.flange_diameter_target ?? null,
+      flange_diameter_tolerance: selectedSpec?.flange_diameter_tolerance ?? null,
       overall_length_actual: formData.overallLength ? parseFloat(formData.overallLength) : null,
-      overall_length_target: spec?.lengthTarget ?? null,
-      overall_length_tolerance: spec?.lengthTol ?? null,
+      overall_length_target: selectedSpec?.overall_length_target ?? null,
+      overall_length_tolerance: selectedSpec?.overall_length_tolerance ?? null,
       length_to_flange_actual: formData.lengthToFlange ? parseFloat(formData.lengthToFlange) : null,
-      length_to_flange_target: spec?.flangeToTarget ?? null,
-      length_to_flange_tolerance: spec?.flangeToTol ?? null,
-      od_measurement_1: formData.od1 ? parseFloat(formData.od1) : null,
-      od_measurement_2: formData.od2 ? parseFloat(formData.od2) : null,
-      od_measurement_3: formData.od3 ? parseFloat(formData.od3) : null,
-      id_measurement_1: formData.id1 ? parseFloat(formData.id1) : null,
-      id_measurement_2: formData.id2 ? parseFloat(formData.id2) : null,
-      length_measurement_1: formData.length1 ? parseFloat(formData.length1) : null,
+      length_to_flange_target: selectedSpec?.length_to_flange_target ?? null,
+      length_to_flange_tolerance: selectedSpec?.length_to_flange_tolerance ?? null,
       material_appearance: formData.materialAppearance || null,
       dimensional_status: formData.dimensionalStatus,
       heat_treat_approved: formData.heatTreatApproved === 'true',
       surface_condition: formData.surfaceCondition || null,
       notes: formData.notes || null,
-      measurement_method: 'CAT_BLAST_EXIT_APP_V1'
+      measurement_method: 'BLAST_EXIT_DYNAMIC_V1'
+    }
+
+    const measurementArrays = [
+      { key: 'odMeasurements', prefix: 'od_measurement_' },
+      { key: 'idMeasurements', prefix: 'id_measurement_' },
+      { key: 'lengthMeasurements', prefix: 'length_measurement_' }
+    ]
+
+    const combinedMeasurements = measurementArrays.reduce((accumulator, { key, prefix }) => {
+      const values = formData[key] || []
+
+      values.forEach((rawValue, index) => {
+        const measurementKey = `${prefix}${index + 1}`
+        const numericValue = rawValue === '' ? null : parseFloat(rawValue)
+        accumulator[measurementKey] = Number.isFinite(numericValue) ? numericValue : null
+      })
+
+      return accumulator
+    }, {})
+
+    const payload = {
+      ...measurementData,
+      ...combinedMeasurements
     }
 
     try {
@@ -354,7 +410,7 @@ export default function BlastExitMeasurement() {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(measurementData)
+        body: JSON.stringify(payload)
       })
 
       const result = await response.json().catch(() => ({}))
@@ -364,8 +420,9 @@ export default function BlastExitMeasurement() {
         throw new Error(message)
       }
 
+      const productLabel = formData.productNumber || 'Measurement'
       setSuccessMessage(
-        `✅ ${formData.productNumber || 'Measurement'} recorded! Heat: ${measurementData.heat_number} | Status: ${measurementData.dimensional_status}`
+        `✅ ${productLabel} recorded successfully! Heat: ${payload.heat_number} | Status: ${payload.dimensional_status} | Heat Treat: ${payload.heat_treat_approved ? 'APPROVED' : 'REJECTED'}`
       )
 
       setTimeout(() => {
@@ -373,6 +430,7 @@ export default function BlastExitMeasurement() {
         setSuccessMessage('')
       }, 3000)
     } catch (error) {
+      console.error('Submission error:', error)
       setErrorMessage(error.message || 'Error submitting measurement. Please try again.')
     } finally {
       setIsSubmitting(false)
@@ -394,354 +452,573 @@ export default function BlastExitMeasurement() {
     )
   }
 
-  const productDetailsMessage = useMemo(() => {
-    if (selectedSpec?.info) {
-      return selectedSpec.info
+  const cylinderSectionTitle = useMemo(() => {
+    if (!selectedSpec) {
+      return 'Cylinder Measurements'
     }
 
-    if (formData.productNumber === 'OTHER') {
-      return 'Manual entry for other CAT products. Use standard measurement procedures.'
+    const descriptor = selectedSpec.product_description || selectedSpec.product_number || 'Cylinder'
+    return `${descriptor} - Critical Measurements`
+  }, [selectedSpec])
+
+  const cylinderMeasurements = useMemo(() => {
+    if (!isCylinder || !selectedSpec) {
+      return []
     }
 
-    return ''
-  }, [formData.productNumber, selectedSpec])
+    const rows = []
+
+    if (showBarrelDiameter) {
+      const target = normalizeNumber(selectedSpec.barrel_diameter_target)
+      rows.push({
+        key: 'barrelDiameter',
+        label: 'Barrel Diameter',
+        target,
+        tolerance: target !== null ? getTolerance(selectedSpec.barrel_diameter_tolerance, 0.02) : null
+      })
+    }
+
+    if (showFlangeDiameter) {
+      const target = normalizeNumber(selectedSpec.flange_diameter_target)
+      rows.push({
+        key: 'flangeDiameter',
+        label: 'Flange Diameter',
+        target,
+        tolerance: target !== null ? getTolerance(selectedSpec.flange_diameter_tolerance, 0.02) : null
+      })
+    }
+
+    if (showOverallLength) {
+      const target = normalizeNumber(selectedSpec.overall_length_target)
+      rows.push({
+        key: 'overallLength',
+        label: 'Overall Length',
+        target,
+        tolerance: target !== null ? getTolerance(selectedSpec.overall_length_tolerance, 0.03) : null
+      })
+    }
+
+    if (showLengthToFlange) {
+      const target = normalizeNumber(selectedSpec.length_to_flange_target)
+      rows.push({
+        key: 'lengthToFlange',
+        label: 'Length to Flange',
+        target,
+        tolerance: target !== null ? getTolerance(selectedSpec.length_to_flange_tolerance, 0.02) : null
+      })
+    }
+
+    return rows
+  }, [
+    isCylinder,
+    selectedSpec,
+    showBarrelDiameter,
+    showFlangeDiameter,
+    showLengthToFlange,
+    showOverallLength
+  ])
+
+  const productFamilyGroups = useMemo(() => {
+    const groups = templates.reduce((accumulator, template) => {
+      const family = template.product_family || 'OTHER'
+      if (!accumulator[family]) {
+        accumulator[family] = []
+      }
+      accumulator[family].push(template)
+      return accumulator
+    }, {})
+
+    Object.values(groups).forEach((group) => {
+      group.sort((a, b) => a.product_number.localeCompare(b.product_number))
+    })
+
+    return groups
+  }, [templates])
 
   return (
     <>
       <Head>
-        <title>📏 CAT Measurement System</title>
+        <title>📏 Blast Exit Measurement - Dynamic Products</title>
       </Head>
-      <div className="min-h-screen bg-gradient-to-br from-amber-300 via-orange-400 to-orange-500 px-4 py-10">
-        <div className="mx-auto max-w-4xl">
+      <div className="min-h-screen bg-gradient-to-br from-indigo-400 via-purple-500 to-purple-700 px-4 py-10">
+        <div className="mx-auto max-w-5xl">
           <div className="rounded-3xl bg-white px-6 py-8 shadow-2xl sm:px-10 sm:py-10">
             <header className="mb-8 text-center text-gray-800">
-              <h1 className="text-3xl font-bold text-amber-500 sm:text-4xl">🏗️ CAT Measurement System</h1>
-              <p className="mt-2 text-lg">Blast Exit Dimensional Control - Phase 1</p>
-              <div className="mt-5 flex flex-wrap justify-center gap-3 text-sm font-semibold text-white">
-                <span className="rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-2">Starting with Top CAT Products</span>
-                <span className="rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-2">536 &amp; 4T Series Priority</span>
-                <span className="rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-2">Ready for Production</span>
-              </div>
+              <h1 className="text-3xl font-bold text-indigo-500 sm:text-4xl">📏 Blast Exit Measurement</h1>
+              <p className="mt-2 text-lg text-slate-600">Dimensional Control System - Phase 1</p>
             </header>
 
+            {loadingTemplates && (
+              <div className="mb-6 rounded-2xl border border-indigo-100 bg-indigo-50 px-4 py-5 text-center text-indigo-600">
+                🔄 Loading CAT products from database...
+              </div>
+            )}
+
+            {loadingError && (
+              <div className="mb-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-5 text-center text-rose-600">
+                ❌ {loadingError}
+              </div>
+            )}
+
             {successMessage && (
-              <div className="mb-6 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-center text-emerald-700 font-semibold">
+              <div className="mb-6 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-5 text-center text-emerald-700 font-semibold">
                 {successMessage}
               </div>
             )}
 
             {errorMessage && (
-              <div className="mb-6 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-center text-rose-700 font-semibold">
+              <div className="mb-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-5 text-center text-rose-700 font-semibold">
                 ❌ {errorMessage}
               </div>
             )}
 
-            <form onSubmit={handleSubmit} className="space-y-8">
-              <section className="rounded-2xl border-2 border-amber-200 bg-amber-50/70 p-5">
-                <label className="block text-sm font-semibold text-gray-700" htmlFor="productNumber">
-                  CAT Product Number <span className="text-rose-500">*</span>
-                </label>
-                <select
-                  id="productNumber"
-                  name="productNumber"
-                  required
-                  value={formData.productNumber}
-                  onChange={handleFieldChange}
-                  className="mt-2 w-full rounded-xl border-2 border-amber-200 bg-white px-4 py-3 font-semibold text-gray-800 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                >
-                  <option value="">Select CAT Product</option>
-                  <option value="CAT536-6765">CAT536-6765 (Cylinder - HIGHEST Priority)</option>
-                  <option value="CAT536-6763">CAT536-6763 (Cylinder - HIGH Priority)</option>
-                  <option value="CAT536-6764">CAT536-6764 (Cylinder - HIGH Priority)</option>
-                  <option value="CAT150-3014">CAT150-3014 (Large Casting)</option>
-                  <option value="CAT150-3011">CAT150-3011 (Large Casting)</option>
-                  <option value="CAT4T-6051">CAT4T-6051 (Heavy Duty - HIGH Priority)</option>
-                  <option value="CAT4T-5937">CAT4T-5937 (Heavy Duty - HIGH Priority)</option>
-                  <option value="CAT4T-4774">CAT4T-4774 (Heavy Duty - MEDIUM Priority)</option>
-                  <option value="CAT121-2077">CAT121-2077 (Large Assembly)</option>
-                  <option value="CAT522-7552">CAT522-7552 (Large Assembly)</option>
-                  <option value="OTHER">Other CAT Product</option>
-                </select>
+            {!loadingTemplates && !loadingError && (
+              <form onSubmit={handleSubmit} className="space-y-8">
+                <section className="rounded-2xl border-2 border-indigo-100 bg-indigo-50/70 p-6">
+                  <label className="block text-sm font-semibold text-slate-700" htmlFor="productNumber">
+                    Product Number <span className="text-rose-500">*</span>
+                  </label>
+                  <select
+                    id="productNumber"
+                    name="productNumber"
+                    required
+                    value={formData.productNumber}
+                    onChange={(event) => {
+                      handleFieldChange(event)
+                      setToleranceStatuses({ ...initialToleranceStatuses })
+                    }}
+                    className="mt-2 w-full rounded-xl border-2 border-indigo-100 bg-white px-4 py-3 font-semibold text-slate-800 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                  >
+                    <option value="">Select Product</option>
+                    {Object.entries(productFamilyGroups).map(([family, familyTemplates]) => {
+                      if (familyTemplates.length > 1) {
+                        return (
+                          <optgroup key={family} label={`${family.replace('_', ' ')} Series`}>
+                            {familyTemplates.map((template) => (
+                              <option key={template.product_number} value={template.product_number}>
+                                {template.product_number} ({template.product_description || 'CAT Product'})
+                              </option>
+                            ))}
+                          </optgroup>
+                        )
+                      }
 
-                {productDetailsMessage && (
-                  <div className="mt-3 rounded-lg bg-white px-3 py-2 text-sm text-gray-600">
-                    {productDetailsMessage}
-                  </div>
-                )}
-              </section>
-
-              <section className="grid gap-6 md:grid-cols-2">
-                <div className="space-y-5">
-                  <div>
-                    <label className="block text-sm font-semibold text-gray-700" htmlFor="heatNumber">
-                      Heat Number <span className="text-rose-500">*</span>
-                    </label>
-                    <input
-                      type="text"
-                      id="heatNumber"
-                      name="heatNumber"
-                      required
-                      value={formData.heatNumber}
-                      onChange={handleFieldChange}
-                      placeholder="Enter heat number"
-                      className="mt-2 w-full rounded-xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-semibold text-gray-700" htmlFor="operator">
-                      Operator <span className="text-rose-500">*</span>
-                    </label>
-                    <input
-                      type="text"
-                      id="operator"
-                      name="operator"
-                      required
-                      value={formData.operator}
-                      onChange={handleFieldChange}
-                      placeholder="Your name"
-                      className="mt-2 w-full rounded-xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                    />
-                  </div>
-                </div>
-                <div className="space-y-5">
-                  <div>
-                    <label className="block text-sm font-semibold text-gray-700" htmlFor="trackingNumber">
-                      Tracking Number
-                    </label>
-                    <input
-                      type="number"
-                      id="trackingNumber"
-                      name="trackingNumber"
-                      value={formData.trackingNumber}
-                      onChange={handleFieldChange}
-                      placeholder="Optional"
-                      className="mt-2 w-full rounded-xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-semibold text-gray-700" htmlFor="shift">
-                      Shift
-                    </label>
-                    <select
-                      id="shift"
-                      name="shift"
-                      value={formData.shift}
-                      onChange={handleFieldChange}
-                      className="mt-2 w-full rounded-xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                    >
-                      <option value="">Select Shift</option>
-                      <option value="1">1st Shift</option>
-                      <option value="2">2nd Shift</option>
-                      <option value="3">3rd Shift</option>
-                    </select>
-                  </div>
-                </div>
-              </section>
-
-              <section className="flex flex-wrap gap-3">
-                <button
-                  type="button"
-                  onClick={autoFill536}
-                  className="rounded-full bg-amber-400 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500"
-                >
-                  ⚡ CAT536-6765
-                </button>
-                <button
-                  type="button"
-                  onClick={autoFill4T}
-                  className="rounded-full bg-amber-400 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500"
-                >
-                  ⚡ CAT4T-6051
-                </button>
-                <button
-                  type="button"
-                  onClick={autoFillLarge}
-                  className="rounded-full bg-amber-400 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-500"
-                >
-                  ⚡ CAT150-3011
-                </button>
-              </section>
-
-              {isCylinder && (
-                <section className="space-y-4 rounded-2xl border-l-4 border-amber-400 bg-slate-50 p-5">
-                  <h3 className="text-xl font-semibold text-amber-500">Cylinder Casting Measurements</h3>
-                  <p className="text-sm text-gray-600">
-                    Use existing measurement sheet procedures. Pi tape for ODs, calipers for lengths.
-                  </p>
-
-                  <div className="space-y-4">
-                    {cylinderMeasurements.map((measurement) => {
-                      const statusKey = toleranceStatuses[measurement.key]
-                      const styles = statusStyles[statusKey] || statusStyles.NONE
-
+                      const template = familyTemplates[0]
                       return (
-                        <div key={measurement.key} className="grid gap-4 rounded-xl bg-white p-4 shadow-sm sm:grid-cols-[1.5fr_1fr_auto] sm:items-end">
-                          <div>
-                            <p className="text-sm font-semibold text-gray-700">{measurement.label}</p>
-                            <p className="text-xs text-gray-500">Target {measurement.target?.toFixed(4)} ±{measurement.tolerance?.toFixed(4)}</p>
-                          </div>
-                          <div>
-                            <input
-                              type="number"
-                              step="0.0001"
-                              inputMode="decimal"
-                              name={measurement.key}
-                              id={measurement.key}
-                              placeholder={measurement.target?.toFixed(4) || '0.0000'}
-                              value={formData[measurement.key]}
-                              onChange={handleFieldChange}
-                              className={`w-full rounded-xl border-2 px-4 py-3 text-center text-lg font-semibold text-gray-800 focus:outline-none focus:ring-4 focus:ring-amber-100 ${styles.input}`}
-                            />
-                          </div>
-                          <div className="text-right">
-                            {renderStatusBadge(statusKey)}
-                          </div>
-                        </div>
+                        <option key={template.product_number} value={template.product_number}>
+                          {template.product_number} ({template.product_description || 'CAT Product'})
+                        </option>
                       )
                     })}
-                  </div>
-                </section>
-              )}
+                    <option value="OTHER">Other Product</option>
+                  </select>
 
-              {showGenericMeasurements && (
-                <section className="rounded-2xl border-l-4 border-amber-400 bg-slate-50 p-5">
-                  <h3 className="text-xl font-semibold text-amber-500">
-                    {formData.productNumber === 'OTHER'
-                      ? 'Other CAT Product Measurements'
-                      : `${formData.productNumber} Measurements`}
-                  </h3>
-                  <p className="text-sm text-gray-600">
-                    Standard measurement procedures for non-cylinder CAT products.
-                  </p>
-                  <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                    {[{ id: 'od1', label: 'Primary OD Measurement' },
-                      { id: 'od2', label: 'Secondary OD Measurement' },
-                      { id: 'od3', label: 'Third OD Measurement (if needed)' },
-                      { id: 'length1', label: 'Critical Length' },
-                      { id: 'id1', label: 'ID Measurement (if applicable)' },
-                      { id: 'id2', label: 'Second ID Measurement (if applicable)' }].map((field) => (
-                      <div key={field.id}>
-                        <label className="block text-sm font-semibold text-gray-700" htmlFor={field.id}>
-                          {field.label}
-                        </label>
-                        <input
-                          type="number"
-                          step="0.0001"
-                          inputMode="decimal"
-                          id={field.id}
-                          name={field.id}
-                          value={formData[field.id]}
-                          onChange={handleFieldChange}
-                          placeholder="0.0000"
-                          className="mt-2 w-full rounded-xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                        />
+                  {formData.productNumber && formData.productNumber !== 'OTHER' && selectedSpec && (
+                    <div className="mt-4 rounded-2xl bg-white p-4">
+                      <div className="text-sm text-slate-600">
+                        <p className="font-semibold text-slate-700">
+                          {selectedSpec.product_description || 'CAT Product'}
+                        </p>
+                        <p className="mt-1">Family: {selectedSpec.product_family || 'Standard'}</p>
+                        <p className="mt-1">
+                          Instructions:{' '}
+                          {selectedSpec.measurement_instructions || 'Standard measurement procedures'}
+                        </p>
+                        <p className="mt-1">
+                          Critical Dimensions:{' '}
+                          {selectedSpec.critical_dimensions || 'Standard dimensions'}
+                        </p>
+                        {selectedSpec.measurement_frequency && (
+                          <p className="mt-1">
+                            Measurement Frequency: {selectedSpec.measurement_frequency}
+                          </p>
+                        )}
+                        {selectedSpec.tolerance_class && (
+                          <p className="mt-1">Tolerance Class: {selectedSpec.tolerance_class}</p>
+                        )}
+                        {selectedSpec.drawing_reference && (
+                          <p className="mt-1">Drawing Reference: {selectedSpec.drawing_reference}</p>
+                        )}
+                        {(odCount || idCount || lengthCount) && (
+                          <ul className="mt-2 list-inside list-disc text-xs text-slate-500 sm:text-sm">
+                            {odCount ? <li>{odCount} OD measurement{odCount > 1 ? 's' : ''}</li> : null}
+                            {idCount ? <li>{idCount} ID measurement{idCount > 1 ? 's' : ''}</li> : null}
+                            {lengthCount ? (
+                              <li>{lengthCount} Length measurement{lengthCount > 1 ? 's' : ''}</li>
+                            ) : null}
+                          </ul>
+                        )}
+                        {selectedSpec.special_requirements && (
+                          <p className="mt-3 rounded-xl bg-indigo-50 p-3 text-sm text-indigo-700">
+                            Special Requirements: {selectedSpec.special_requirements}
+                          </p>
+                        )}
+                        {(scrapThreshold !== null || reworkThreshold !== null) && (
+                          <p className="mt-2 text-xs font-semibold text-rose-600">
+                            {scrapThreshold !== null ? `Scrap review ≥ ${scrapThreshold}%` : ''}
+                            {scrapThreshold !== null && reworkThreshold !== null ? ' • ' : ''}
+                            {reworkThreshold !== null ? `Rework review ≥ ${reworkThreshold}%` : ''}
+                          </p>
+                        )}
                       </div>
-                    ))}
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {selectedSpec.priority_score !== null && selectedSpec.priority_score !== undefined && (
+                          <span
+                            className={`rounded-full px-3 py-1 text-xs font-semibold text-white ${
+                              selectedSpec.priority_score >= 9
+                                ? 'bg-rose-500'
+                                : selectedSpec.priority_score >= 7
+                                  ? 'bg-orange-500'
+                                  : 'bg-slate-500'
+                            }`}
+                          >
+                            Priority {selectedSpec.priority_score}
+                          </span>
+                        )}
+                        {selectedSpec.volume_classification && (
+                          <span className="rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">
+                            {selectedSpec.volume_classification} Volume
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </section>
+
+                <section className="grid gap-6 md:grid-cols-2">
+                  <div className="space-y-5">
+                    <div>
+                      <label className="block text-sm font-semibold text-slate-700" htmlFor="heatNumber">
+                        Heat Number <span className="text-rose-500">*</span>
+                      </label>
+                      <input
+                        type="text"
+                        id="heatNumber"
+                        name="heatNumber"
+                        required
+                        value={formData.heatNumber}
+                        onChange={handleFieldChange}
+                        placeholder="Enter heat number"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-semibold text-slate-700" htmlFor="operator">
+                        Operator <span className="text-rose-500">*</span>
+                      </label>
+                      <input
+                        type="text"
+                        id="operator"
+                        name="operator"
+                        required
+                        value={formData.operator}
+                        onChange={handleFieldChange}
+                        placeholder="Your name"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-5">
+                    <div>
+                      <label className="block text-sm font-semibold text-slate-700" htmlFor="trackingNumber">
+                        Tracking Number
+                      </label>
+                      <input
+                        type="number"
+                        id="trackingNumber"
+                        name="trackingNumber"
+                        value={formData.trackingNumber}
+                        onChange={handleFieldChange}
+                        placeholder="Optional"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-semibold text-slate-700" htmlFor="shift">
+                        Shift
+                      </label>
+                      <select
+                        id="shift"
+                        name="shift"
+                        value={formData.shift}
+                        onChange={handleFieldChange}
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                      >
+                        <option value="">Select Shift</option>
+                        <option value="1">1st Shift</option>
+                        <option value="2">2nd Shift</option>
+                        <option value="3">3rd Shift</option>
+                      </select>
+                    </div>
                   </div>
                 </section>
-              )}
 
-              <section className="rounded-2xl border-l-4 border-amber-400 bg-slate-50 p-5">
-                <h3 className="text-xl font-semibold text-amber-500">Casting Conditions &amp; Quality</h3>
-                <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                  <div>
-                    <label className="block text-sm font-semibold text-gray-700" htmlFor="materialAppearance">
-                      Material Appearance
-                    </label>
-                    <select
-                      id="materialAppearance"
-                      name="materialAppearance"
-                      value={formData.materialAppearance}
-                      onChange={handleFieldChange}
-                      className="mt-2 w-full rounded-xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                    >
-                      <option value="">Select Condition</option>
-                      <option value="EXCELLENT">Excellent - Perfect Cast</option>
-                      <option value="GOOD">Good - Minor Surface Issues</option>
-                      <option value="FAIR">Fair - Some Defects</option>
-                      <option value="POOR">Poor - Major Problems</option>
-                    </select>
+                <section className="flex flex-wrap gap-3">
+                  <button
+                    type="button"
+                    onClick={quickFillHeat}
+                    className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-600"
+                  >
+                    ⚡ Quick Heat#
+                  </button>
+                  <button
+                    type="button"
+                    onClick={loadLastMeasurement}
+                    className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-600"
+                  >
+                    🔄 Load Last
+                  </button>
+                  <button
+                    type="button"
+                    onClick={showInstructions}
+                    className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-600"
+                  >
+                    📖 Instructions
+                  </button>
+                </section>
+
+                {isCylinder && cylinderMeasurements.length > 0 && (
+                  <section className="rounded-2xl border-l-4 border-indigo-400 bg-slate-50 p-6">
+                    <h3 className="text-xl font-semibold text-indigo-500">{cylinderSectionTitle}</h3>
+                    <p className="mt-2 text-sm italic text-slate-600">
+                      {selectedSpec?.measurement_instructions || 'Use Pi tape for ODs, calipers for lengths.'}
+                    </p>
+
+                    <div className="mt-5 space-y-4">
+                      {cylinderMeasurements.map((measurement) => {
+                        const statusKey = toleranceStatuses[measurement.key]
+                        const styles = statusStyles[statusKey] || statusStyles.NONE
+                        const hasTarget = measurement.target !== null && measurement.target !== undefined
+                        const targetText = hasTarget ? measurement.target : 'Refer to drawing'
+                        const toleranceText = hasTarget && Number.isFinite(measurement.tolerance)
+                          ? ` ±${measurement.tolerance}`
+                          : ''
+
+                        return (
+                          <div
+                            key={measurement.key}
+                            className="grid gap-4 rounded-xl bg-white p-4 shadow-sm sm:grid-cols-[2fr_1fr_auto] sm:items-center"
+                          >
+                            <div>
+                              <div className="font-semibold text-slate-700">{measurement.label}</div>
+                              <div className="text-sm text-slate-500">
+                                Target: {targetText}
+                                {toleranceText}
+                              </div>
+                            </div>
+                            <div>
+                              <input
+                                type="number"
+                                step="0.0001"
+                                name={measurement.key}
+                                value={formData[measurement.key]}
+                                onChange={handleFieldChange}
+                                placeholder="0.0000"
+                                className={`mt-1 w-full rounded-xl border-2 px-4 py-3 text-center text-lg font-semibold transition focus:outline-none focus:ring-4 focus:ring-indigo-100 ${styles.input}`}
+                              />
+                            </div>
+                            <div className="flex justify-end">{renderStatusBadge(statusKey)}</div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </section>
+                )}
+
+                {!isCylinder && formData.productNumber && (
+                  <section className="rounded-2xl border-l-4 border-indigo-400 bg-slate-50 p-6">
+                    <h3 className="text-xl font-semibold text-indigo-500">
+                      {formData.productNumber === 'OTHER'
+                        ? 'Standard Measurements'
+                        : `${formData.productNumber} Measurements`}
+                    </h3>
+                    <p className="mt-2 text-sm italic text-slate-600">
+                      {selectedSpec?.measurement_instructions ||
+                        'Standard measurement procedures. Enter dimensions as available.'}
+                    </p>
+
+                    {odCount || idCount || lengthCount ? (
+                      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                        {formData.odMeasurements.map((value, index) => {
+                          const fieldId = `od-measurement-${index + 1}`
+                          return (
+                            <div key={fieldId}>
+                              <label className="block text-sm font-semibold text-slate-700" htmlFor={fieldId}>
+                                OD Measurement {index + 1}
+                              </label>
+                              <input
+                                type="number"
+                                step="0.0001"
+                                id={fieldId}
+                                name={fieldId}
+                                value={value}
+                                onChange={(event) =>
+                                  handleMeasurementChange('odMeasurements', index, event.target.value)
+                                }
+                                placeholder="0.0000"
+                                className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                              />
+                            </div>
+                          )
+                        })}
+
+                        {formData.idMeasurements.map((value, index) => {
+                          const fieldId = `id-measurement-${index + 1}`
+                          return (
+                            <div key={fieldId}>
+                              <label className="block text-sm font-semibold text-slate-700" htmlFor={fieldId}>
+                                ID Measurement {index + 1}
+                              </label>
+                              <input
+                                type="number"
+                                step="0.0001"
+                                id={fieldId}
+                                name={fieldId}
+                                value={value}
+                                onChange={(event) =>
+                                  handleMeasurementChange('idMeasurements', index, event.target.value)
+                                }
+                                placeholder="0.0000"
+                                className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                              />
+                            </div>
+                          )
+                        })}
+
+                        {formData.lengthMeasurements.map((value, index) => {
+                          const fieldId = `length-measurement-${index + 1}`
+                          return (
+                            <div key={fieldId}>
+                              <label className="block text-sm font-semibold text-slate-700" htmlFor={fieldId}>
+                                Length Measurement {index + 1}
+                              </label>
+                              <input
+                                type="number"
+                                step="0.0001"
+                                id={fieldId}
+                                name={fieldId}
+                                value={value}
+                                onChange={(event) =>
+                                  handleMeasurementChange('lengthMeasurements', index, event.target.value)
+                                }
+                                placeholder="0.0000"
+                                className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                              />
+                            </div>
+                          )
+                        })}
+                      </div>
+                    ) : (
+                      <div className="mt-4 rounded-xl bg-white px-4 py-5 text-sm text-slate-600">
+                        No dimensional inputs are configured for this template. Use the notes section to capture any
+                        findings.
+                      </div>
+                    )}
+                  </section>
+                )}
+
+                <section className="rounded-2xl border-l-4 border-indigo-400 bg-slate-50 p-6">
+                  <h3 className="text-xl font-semibold text-indigo-500">Quality Assessment</h3>
+                  <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-semibold text-slate-700" htmlFor="materialAppearance">
+                        Material Appearance
+                      </label>
+                      <select
+                        id="materialAppearance"
+                        name="materialAppearance"
+                        value={formData.materialAppearance}
+                        onChange={handleFieldChange}
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                      >
+                        <option value="">Select Condition</option>
+                        <option value="EXCELLENT">Excellent - Perfect Cast</option>
+                        <option value="GOOD">Good - Minor Issues</option>
+                        <option value="FAIR">Fair - Some Defects</option>
+                        <option value="POOR">Poor - Major Problems</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-sm font-semibold text-slate-700" htmlFor="dimensionalStatus">
+                        Overall Dimensional Status
+                      </label>
+                      <select
+                        id="dimensionalStatus"
+                        name="dimensionalStatus"
+                        required
+                        value={formData.dimensionalStatus}
+                        onChange={handleFieldChange}
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                      >
+                        <option value="PASS">✅ PASS - All dimensions OK</option>
+                        <option value="MARGINAL">⚠️ MARGINAL - Close to limits</option>
+                        <option value="FAIL">❌ FAIL - Out of tolerance</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-sm font-semibold text-slate-700" htmlFor="heatTreatApproved">
+                        Heat Treatment Approval
+                      </label>
+                      <select
+                        id="heatTreatApproved"
+                        name="heatTreatApproved"
+                        required
+                        value={formData.heatTreatApproved}
+                        onChange={handleFieldChange}
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                      >
+                        <option value="true">✅ APPROVED - Send to Heat Treat</option>
+                        <option value="false">❌ REJECTED - Hold/Scrap</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-sm font-semibold text-slate-700" htmlFor="surfaceCondition">
+                        Surface Condition
+                      </label>
+                      <select
+                        id="surfaceCondition"
+                        name="surfaceCondition"
+                        value={formData.surfaceCondition}
+                        onChange={handleFieldChange}
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                      >
+                        <option value="">Select Condition</option>
+                        <option value="SMOOTH">Smooth - No Issues</option>
+                        <option value="ROUGH">Rough Surface</option>
+                        <option value="INCLUSIONS">Visible Inclusions</option>
+                        <option value="POROSITY">Surface Porosity</option>
+                        <option value="COLD_SHUT">Cold Shut Present</option>
+                      </select>
+                    </div>
                   </div>
-                  <div>
-                    <label className="block text-sm font-semibold text-gray-700" htmlFor="dimensionalStatus">
-                      Overall Dimensional Status
-                    </label>
-                    <select
-                      id="dimensionalStatus"
-                      name="dimensionalStatus"
-                      required
-                      value={formData.dimensionalStatus}
-                      onChange={handleFieldChange}
-                      className="mt-2 w-full rounded-xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                    >
-                      <option value="PASS">✅ PASS - All dimensions OK</option>
-                      <option value="MARGINAL">⚠️ MARGINAL - Close to limits</option>
-                      <option value="FAIL">❌ FAIL - Out of tolerance</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-semibold text-gray-700" htmlFor="heatTreatApproved">
-                      Heat Treatment Decision
-                    </label>
-                    <select
-                      id="heatTreatApproved"
-                      name="heatTreatApproved"
-                      required
-                      value={formData.heatTreatApproved}
-                      onChange={handleFieldChange}
-                      className="mt-2 w-full rounded-xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                    >
-                      <option value="true">✅ APPROVED - Send to Heat Treat</option>
-                      <option value="false">❌ REJECTED - Hold/Scrap</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-semibold text-gray-700" htmlFor="surfaceCondition">
-                      Surface Condition
-                    </label>
-                    <select
-                      id="surfaceCondition"
-                      name="surfaceCondition"
-                      value={formData.surfaceCondition}
-                      onChange={handleFieldChange}
-                      className="mt-2 w-full rounded-xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                    >
-                      <option value="">Select Condition</option>
-                      <option value="SMOOTH">Smooth - No Issues</option>
-                      <option value="ROUGH">Rough Surface</option>
-                      <option value="INCLUSIONS">Visible Inclusions</option>
-                      <option value="POROSITY">Surface Porosity</option>
-                      <option value="COLD_SHUT">Cold Shut Present</option>
-                    </select>
-                  </div>
+                </section>
+
+                <section>
+                  <label className="block text-sm font-semibold text-slate-700" htmlFor="notes">
+                    Notes &amp; Observations
+                  </label>
+                  <textarea
+                    id="notes"
+                    name="notes"
+                    rows={4}
+                    value={formData.notes}
+                    onChange={handleFieldChange}
+                    placeholder="Record observations about casting quality, measurement issues, or recommendations..."
+                    className="mt-2 w-full rounded-2xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                  />
+                </section>
+
+                <div>
+                  <button
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="w-full rounded-full bg-gradient-to-r from-indigo-500 to-purple-500 px-6 py-4 text-lg font-semibold uppercase tracking-wide text-white shadow-lg transition hover:shadow-xl disabled:cursor-not-allowed disabled:from-slate-300 disabled:to-slate-400"
+                  >
+                    {isSubmitting ? '⏳ Submitting...' : '📏 Submit Measurement'}
+                  </button>
                 </div>
-              </section>
-
-              <section>
-                <label className="block text-sm font-semibold text-gray-700" htmlFor="notes">
-                  Measurement Notes &amp; Observations
-                </label>
-                <textarea
-                  id="notes"
-                  name="notes"
-                  rows={4}
-                  value={formData.notes}
-                  onChange={handleFieldChange}
-                  placeholder="Record observations about casting quality, measurement issues, or recommendations..."
-                  className="mt-2 w-full rounded-2xl border-2 border-gray-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-amber-100"
-                />
-              </section>
-
-              <div>
-                <button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="w-full rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-6 py-4 text-lg font-semibold uppercase tracking-wide text-white shadow-lg transition hover:shadow-xl disabled:cursor-not-allowed disabled:from-gray-300 disabled:to-gray-400"
-                >
-                  {isSubmitting ? '⏳ Submitting...' : '📏 Submit CAT Measurement'}
-                </button>
-              </div>
-            </form>
+              </form>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- reset blast exit form state from a factory so we can manage dynamic OD/ID/length arrays alongside the existing cylinder fields
- drive cylinder detection, tolerance checking, and measurement rendering from the template `requires_*` flags and configured counts, including a richer product metadata panel
- post Supabase payloads with the generated measurement arrays while providing fallbacks when templates omit dimensional inputs

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d49d102c54832ab1b2dcfd0515ee62