### PR TITLE
Use local QR code library

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "date-fns": "^3.3.1",
     "lucide-react": "^0.284.0",
     "next": "^14.1.0",
+    "qrcode": "^1.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.8.0"


### PR DESCRIPTION
## Summary
- replace the CDN-based QR code script with a dynamically imported npm dependency so the generator works offline and reports errors through state
- guard QR code generation handlers with the loaded library instance to avoid attempts before it is ready
- add the `qrcode` package to project dependencies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4adecd28c832a85da10821c281bb5