### PR TITLE
Apply Spuncast branding across tooling tracker

### DIFF
--- a/components/ToolChangeForm.js
+++ b/components/ToolChangeForm.js
@@ -610,11 +610,11 @@ const ToolChangeForm = () => {
 
   if (toolsLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-spuncast-sky flex items-center justify-center">
         <div className="text-center">
-          <RefreshCw className="animate-spin h-8 w-8 text-blue-600 mx-auto mb-4" />
-          <p className="text-gray-600">Loading tool inventory from database...</p>
-          <p className="text-sm text-gray-500 mt-2">Fetching from tool_inventory_enhanced table</p>
+          <RefreshCw className="mx-auto mb-4 h-8 w-8 animate-spin text-spuncast-navy" />
+          <p className="text-spuncast-slate/80">Loading tool inventory from database...</p>
+          <p className="text-sm text-spuncast-slate/70 mt-2">Fetching from tool_inventory_enhanced table</p>
         </div>
       </div>
     );
@@ -624,17 +624,17 @@ const ToolChangeForm = () => {
   const groupedFinishingTools = groupToolsByGeometry(availableTools.finishing);
 
   return (
-    <div className="max-w-6xl mx-auto p-6 bg-white">
+    <div className="max-w-6xl mx-auto rounded-3xl border border-white/60 bg-white p-8 shadow-brand">
       <div className="mb-6">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Enhanced Tool Change Form</h1>
-        <p className="text-gray-600">Professional tool tracking with inventory integration</p>
-        <div className="flex items-center gap-4 mt-2 text-sm text-gray-500">
+        <h1 className="mb-2 text-3xl font-bold text-spuncast-navy">Enhanced Tool Change Form</h1>
+        <p className="text-spuncast-slate/80">Professional tool tracking with inventory integration</p>
+        <div className="mt-2 flex items-center gap-4 text-sm text-spuncast-slate/70">
           <span>📊 Tools Available: {availableTools.all.length}</span>
           <span>🔧 Roughing: {availableTools.roughing.length}</span>
           <span>✨ Finishing: {availableTools.finishing.length}</span>
         </div>
-        <div className="mt-3 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-          <p className="text-sm text-yellow-800">
+        <div className="mt-3 p-3 bg-spuncast-sky border border-spuncast-red/20 rounded-lg">
+          <p className="text-sm text-spuncast-slate">
             <strong>Note:</strong> You can change either Rougher tools OR Finisher tools or both. 
             Fill out only the sections for tools you're actually changing.
           </p>
@@ -643,21 +643,21 @@ const ToolChangeForm = () => {
 
       {/* Cost Summary Panel */}
       {costSummary.totalCost > 0 && (
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
-          <h3 className="text-lg font-semibold text-blue-900 mb-2 flex items-center">
+        <div className="bg-spuncast-sky border border-spuncast-navy/10 rounded-lg p-4 mb-6">
+          <h3 className="text-lg font-semibold text-spuncast-navy mb-2 flex items-center">
             <DollarSign className="mr-2" size={20} />
             Tool Change Cost Summary
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
             <div>
-              <span className="text-blue-700 font-medium">New Tool Cost:</span>
+              <span className="text-spuncast-navy font-medium">New Tool Cost:</span>
               <span className="ml-2 font-bold">${costSummary.newToolCost.toFixed(2)}</span>
             </div>
             <div>
-              <span className="text-blue-700 font-medium">Total Change Cost:</span>
+              <span className="text-spuncast-navy font-medium">Total Change Cost:</span>
               <span className="ml-2 font-bold text-lg">${costSummary.totalCost.toFixed(2)}</span>
             </div>
-            <div className="text-xs text-blue-600">
+            <div className="text-xs text-spuncast-navy">
               <Package2 className="inline mr-1" size={12} />
               Based on current inventory prices
             </div>
@@ -702,14 +702,14 @@ const ToolChangeForm = () => {
       )}
 
       {/* Basic Information Section */}
-      <div className="bg-blue-50 p-6 rounded-lg mb-6">
-        <h2 className="text-xl font-semibold text-blue-900 mb-4 flex items-center">
+      <div className="bg-spuncast-sky p-6 rounded-lg mb-6">
+        <h2 className="text-xl font-semibold text-spuncast-navy mb-4 flex items-center">
           <Clock className="mr-2" size={20} />
           Basic Information
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Heat Number <span className="text-red-500">*</span>
             </label>
             <input
@@ -719,11 +719,11 @@ const ToolChangeForm = () => {
               onChange={handleInputChange}
               required
               placeholder="Enter heat number"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Date <span className="text-red-500">*</span>
             </label>
             <input
@@ -732,11 +732,11 @@ const ToolChangeForm = () => {
               value={formData.date}
               onChange={handleInputChange}
               required
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Time <span className="text-red-500">*</span>
             </label>
             <input
@@ -745,11 +745,11 @@ const ToolChangeForm = () => {
               value={formData.time}
               onChange={handleInputChange}
               required
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Shift <span className="text-red-500">*</span>
             </label>
             <select
@@ -757,7 +757,7 @@ const ToolChangeForm = () => {
               value={formData.shift}
               onChange={handleInputChange}
               required
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
             >
               <option value="">Select shift</option>
               <option value="1">1st Shift (6AM-2PM)</option>
@@ -769,14 +769,14 @@ const ToolChangeForm = () => {
       </div>
 
       {/* Operator Information Section */}
-      <div className="bg-purple-50 p-6 rounded-lg mb-6">
-        <h2 className="text-xl font-semibold text-purple-900 mb-4 flex items-center">
+      <div className="bg-spuncast-sky p-6 rounded-lg mb-6">
+        <h2 className="text-xl font-semibold text-spuncast-navy mb-4 flex items-center">
           <User className="mr-2" size={20} />
           Operator Information
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Operator <span className="text-red-500">*</span>
             </label>
             <select
@@ -784,7 +784,7 @@ const ToolChangeForm = () => {
               value={selectedOperatorValue}
               onChange={handleOperatorSelect}
               required
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500 disabled:bg-gray-100 disabled:text-gray-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20 disabled:bg-gray-100 disabled:text-spuncast-slate/70"
               disabled={!operators.length}
             >
               <option value="">Select operator</option>
@@ -796,7 +796,7 @@ const ToolChangeForm = () => {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Work Center <span className="text-red-500">*</span>
             </label>
             <input
@@ -806,11 +806,11 @@ const ToolChangeForm = () => {
               onChange={handleInputChange}
               required
               placeholder="Enter work center"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Equipment Number <span className="text-red-500">*</span>
             </label>
             <input
@@ -820,11 +820,11 @@ const ToolChangeForm = () => {
               onChange={handleInputChange}
               required
               placeholder="Enter equipment number"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Operation <span className="text-red-500">*</span>
             </label>
             <select
@@ -832,7 +832,7 @@ const ToolChangeForm = () => {
               value={formData.operation}
               onChange={handleInputChange}
               required
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
             >
               <option value="Bore">Bore</option>
               <option value="Turn">Turn</option>
@@ -841,7 +841,7 @@ const ToolChangeForm = () => {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Part Number <span className="text-red-500">*</span>
             </label>
             <input
@@ -851,11 +851,11 @@ const ToolChangeForm = () => {
               onChange={handleInputChange}
               required
               placeholder="Enter part number"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Job Number
             </label>
             <input
@@ -864,32 +864,32 @@ const ToolChangeForm = () => {
               value={formData.job_number}
               onChange={handleInputChange}
               placeholder="Enter job number (optional)"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
             />
           </div>
         </div>
       </div>
 
       {/* Enhanced Tool Change Information Section */}
-      <div className="bg-orange-50 p-6 rounded-lg mb-6">
-        <h2 className="text-xl font-semibold text-orange-900 mb-4 flex items-center">
+      <div className="bg-white p-6 rounded-lg mb-6">
+        <h2 className="text-xl font-semibold text-spuncast-red mb-4 flex items-center">
           <Package className="mr-2" size={20} />
           Tool Selection (Choose One or Both)
         </h2>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
           {/* First Rougher Section */}
           <div className="space-y-4">
-            <h3 className="text-lg font-medium text-gray-800 border-b pb-2">First Rougher (Optional)</h3>
+            <h3 className="text-lg font-medium text-spuncast-navy border-b pb-2">First Rougher (Optional)</h3>
             
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-spuncast-slate mb-1">
                 Current First Rougher
               </label>
               <select
                 name="old_first_rougher"
                 value={formData.old_first_rougher}
                 onChange={handleInputChange}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30"
               >
                 <option value="">Select current roughing tool</option>
                 {Object.entries(groupedRoughingTools).map(([geometry, tools]) => (
@@ -906,7 +906,7 @@ const ToolChangeForm = () => {
                 ))}
               </select>
               {formData.first_rougher_action === 'New Insert' && formData.old_first_rougher && formData.new_first_rougher && (
-                <div className="mt-2 p-3 bg-blue-50 border border-blue-200 rounded text-sm">
+                <div className="mt-2 p-3 bg-spuncast-sky border border-spuncast-navy/10 rounded text-sm">
                   {(() => {
                     const tool = getToolDetails(formData.old_first_rougher);
                     return tool ? (
@@ -922,7 +922,7 @@ const ToolChangeForm = () => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-spuncast-slate mb-1">
                 New First Rougher
               </label>
               <select
@@ -930,7 +930,7 @@ const ToolChangeForm = () => {
                 value={formData.new_first_rougher}
                 onChange={handleInputChange}
                 disabled={formData.first_rougher_action !== 'New Insert'}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:bg-gray-100"
+                className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30 disabled:bg-gray-100"
               >
                 <option value="">Select replacement roughing tool</option>
                 {Object.entries(groupedRoughingTools).map(([geometry, tools]) => (
@@ -965,14 +965,14 @@ const ToolChangeForm = () => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-spuncast-slate mb-1">
                 Rougher Action
               </label>
               <select
                 name="first_rougher_action"
                 value={formData.first_rougher_action}
                 onChange={handleInputChange}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30"
               >
                 <option value="">Select action</option>
                 <option value="New Insert">New Insert (New Cost)</option>
@@ -981,7 +981,7 @@ const ToolChangeForm = () => {
             </div>
             {formData.first_rougher_action === 'New Insert' && formData.old_first_rougher && formData.new_first_rougher && (
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-spuncast-slate mb-1">
                   Rougher Change Reason <span className="text-red-500">*</span>
                 </label>
                 <select
@@ -989,7 +989,7 @@ const ToolChangeForm = () => {
                   value={formData.first_rougher_change_reason}
                   onChange={handleInputChange}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30"
                 >
                   <option value="">Select reason</option>
                   <option value="Normal wear">Normal wear</option>
@@ -1005,17 +1005,17 @@ const ToolChangeForm = () => {
 
           {/* Finish Tool Section */}
           <div className="space-y-4">
-            <h3 className="text-lg font-medium text-gray-800 border-b pb-2">Finish Tool (Optional)</h3>
+            <h3 className="text-lg font-medium text-spuncast-navy border-b pb-2">Finish Tool (Optional)</h3>
             
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-spuncast-slate mb-1">
                 Current Finish Tool
               </label>
               <select
                 name="old_finish_tool"
                 value={formData.old_finish_tool}
                 onChange={handleInputChange}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30"
               >
                 <option value="">Select current finishing tool</option>
                 {Object.entries(groupedFinishingTools).map(([geometry, tools]) => (
@@ -1032,7 +1032,7 @@ const ToolChangeForm = () => {
                 ))}
               </select>
               {formData.finish_tool_action === 'New Insert' && formData.old_finish_tool && formData.new_finish_tool && (
-                <div className="mt-2 p-3 bg-blue-50 border border-blue-200 rounded text-sm">
+                <div className="mt-2 p-3 bg-spuncast-sky border border-spuncast-navy/10 rounded text-sm">
                   {(() => {
                     const tool = getToolDetails(formData.old_finish_tool);
                     return tool ? (
@@ -1048,7 +1048,7 @@ const ToolChangeForm = () => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-spuncast-slate mb-1">
                 New Finish Tool
               </label>
               <select
@@ -1056,7 +1056,7 @@ const ToolChangeForm = () => {
                 value={formData.new_finish_tool}
                 onChange={handleInputChange}
                 disabled={formData.finish_tool_action !== 'New Insert'}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:bg-gray-100"
+                className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30 disabled:bg-gray-100"
               >
                 <option value="">Select replacement finishing tool</option>
                 {Object.entries(groupedFinishingTools).map(([geometry, tools]) => (
@@ -1091,14 +1091,14 @@ const ToolChangeForm = () => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-spuncast-slate mb-1">
                 Finish Action
               </label>
               <select
                 name="finish_tool_action"
                 value={formData.finish_tool_action}
                 onChange={handleInputChange}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30"
               >
                 <option value="">Select action</option>
                 <option value="New Insert">New Insert (New Cost)</option>
@@ -1107,7 +1107,7 @@ const ToolChangeForm = () => {
             </div>
             {formData.finish_tool_action === 'New Insert' && formData.old_finish_tool && formData.new_finish_tool && (
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-spuncast-slate mb-1">
                   Finish Change Reason <span className="text-red-500">*</span>
                 </label>
                 <select
@@ -1115,7 +1115,7 @@ const ToolChangeForm = () => {
                   value={formData.finish_tool_change_reason}
                   onChange={handleInputChange}
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30"
                 >
                   <option value="">Select reason</option>
                   <option value="Normal wear">Normal wear</option>
@@ -1132,21 +1132,21 @@ const ToolChangeForm = () => {
       </div>
 
       {/* Material Information Section */}
-      <div className="bg-yellow-50 p-6 rounded-lg mb-6">
-        <h2 className="text-xl font-semibold text-yellow-900 mb-4 flex items-center">
+      <div className="bg-spuncast-sky p-6 rounded-lg mb-6">
+        <h2 className="text-xl font-semibold text-spuncast-navy mb-4 flex items-center">
           <TrendingUp className="mr-2" size={20} />
           Material & Process Information
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-spuncast-slate mb-1">
               Material Appearance
             </label>
             <select
               name="material_appearance"
               value={formData.material_appearance}
               onChange={handleInputChange}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
+              className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30"
             >
               <option value="Normal">Normal</option>
               <option value="Hard spots">Hard spots</option>
@@ -1157,7 +1157,7 @@ const ToolChangeForm = () => {
           </div>
         </div>
         <div className="mt-4">
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-spuncast-slate mb-1">
             Additional Notes
           </label>
           <textarea
@@ -1166,7 +1166,7 @@ const ToolChangeForm = () => {
             onChange={handleInputChange}
             rows={3}
             placeholder="Enter any additional observations or notes..."
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
+            className="w-full px-3 py-2 border border-spuncast-navy/10 rounded-md focus:outline-none focus:ring-2 focus:ring-spuncast-red/30"
           />
         </div>
       </div>
@@ -1176,7 +1176,7 @@ const ToolChangeForm = () => {
         <button
           onClick={handleSubmit}
           disabled={isSubmitting}
-          className="flex items-center px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200"
+          className="flex items-center rounded-full bg-spuncast-navy px-6 py-3 text-white shadow-brand transition-colors duration-200 hover:bg-spuncast-navyDark disabled:cursor-not-allowed disabled:opacity-50"
         >
           {isSubmitting ? (
             <>

--- a/pages/additional-data.js
+++ b/pages/additional-data.js
@@ -28,63 +28,70 @@ export default function AdditionalData() {
   }
 
   return (
-    <main className="max-w-3xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Additional Performance Data</h1>
-      <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <main className="min-h-screen bg-gradient-to-b from-spuncast-navy/10 via-spuncast-sky to-white py-12">
+      <div className="mx-auto max-w-3xl rounded-3xl border border-white/60 bg-white px-6 py-8 shadow-brand">
+        <h1 className="text-3xl font-bold text-spuncast-navy mb-6">Additional Performance Data</h1>
+        <form onSubmit={handleSubmit} className="grid grid-cols-1 gap-5 md:grid-cols-2">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Old Tool Condition</label>
+          <label className="mb-1 block text-sm font-semibold text-spuncast-slate">Old Tool Condition</label>
           <input
             type="text"
             name="old_tool_condition"
             value={data.old_tool_condition}
             onChange={handleChange}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
+            className="w-full rounded-xl border border-spuncast-navy/10 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Failure Mode</label>
+          <label className="mb-1 block text-sm font-semibold text-spuncast-slate">Failure Mode</label>
           <input
             type="text"
             name="failure_mode"
             value={data.failure_mode}
             onChange={handleChange}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
+            className="w-full rounded-xl border border-spuncast-navy/10 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Pieces Produced</label>
+          <label className="mb-1 block text-sm font-semibold text-spuncast-slate">Pieces Produced</label>
           <input
             type="number"
             name="pieces_produced"
             value={data.pieces_produced}
             onChange={handleChange}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
+            className="w-full rounded-xl border border-spuncast-navy/10 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Scrap Pieces</label>
+          <label className="mb-1 block text-sm font-semibold text-spuncast-slate">Scrap Pieces</label>
           <input
             type="number"
             name="scrap_pieces"
             value={data.scrap_pieces}
             onChange={handleChange}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
+            className="w-full rounded-xl border border-spuncast-navy/10 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Rework Pieces</label>
+          <label className="mb-1 block text-sm font-semibold text-spuncast-slate">Rework Pieces</label>
           <input
             type="number"
             name="rework_pieces"
             value={data.rework_pieces}
             onChange={handleChange}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500"
+            className="w-full rounded-xl border border-spuncast-navy/10 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
           />
         </div>
         <div className="md:col-span-2">
-          <button type="submit" className="bg-yellow-500 text-white px-4 py-2 rounded-md">Submit</button>
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-full bg-spuncast-red px-6 py-3 font-semibold uppercase tracking-wide text-white shadow-brand transition hover:bg-spuncast-redDark"
+          >
+            Submit
+          </button>
         </div>
       </form>
+      </div>
     </main>
   )
 }

--- a/pages/blast-exit.js
+++ b/pages/blast-exit.js
@@ -855,16 +855,16 @@ export default function BlastExitMeasurement() {
       <Head>
         <title>📏 Blast Exit Measurement - Dynamic Products</title>
       </Head>
-      <div className="min-h-screen bg-gradient-to-br from-indigo-400 via-purple-500 to-purple-700 px-4 py-10">
+      <div className="min-h-screen bg-gradient-to-br from-spuncast-navy via-spuncast-navyDark to-spuncast-red px-4 py-10">
         <div className="mx-auto max-w-5xl">
-          <div className="rounded-3xl bg-white px-6 py-8 shadow-2xl sm:px-10 sm:py-10">
-            <header className="mb-8 text-center text-gray-800">
-              <h1 className="text-3xl font-bold text-indigo-500 sm:text-4xl">📏 Blast Exit Measurement</h1>
+          <div className="rounded-3xl border border-white/60 bg-white px-6 py-8 shadow-brand sm:px-10 sm:py-10">
+            <header className="mb-8 text-center text-spuncast-slate">
+              <h1 className="text-3xl font-bold text-spuncast-navy sm:text-4xl">📏 Blast Exit Measurement</h1>
               <p className="mt-2 text-lg text-slate-600">Dimensional Control System - Phase 1</p>
             </header>
 
             {loadingTemplates && (
-              <div className="mb-6 rounded-2xl border border-indigo-100 bg-indigo-50 px-4 py-5 text-center text-indigo-600">
+              <div className="mb-6 rounded-2xl border border-spuncast-navy/10 bg-spuncast-sky px-4 py-5 text-center text-spuncast-navy">
                 🔄 Loading CAT products from database...
               </div>
             )}
@@ -895,7 +895,7 @@ export default function BlastExitMeasurement() {
 
             {!loadingTemplates && templates.length > 0 && (
               <form onSubmit={handleSubmit} className="space-y-8">
-                <section className="rounded-2xl border-2 border-indigo-100 bg-indigo-50/70 p-6">
+                <section className="rounded-2xl border-2 border-spuncast-navy/10 bg-spuncast-sky/70 p-6">
                   <label className="block text-sm font-semibold text-slate-700" htmlFor="productNumber">
                     Product Number <span className="text-rose-500">*</span>
                   </label>
@@ -905,7 +905,7 @@ export default function BlastExitMeasurement() {
                     required
                     value={formData.productNumber}
                     onChange={handleFieldChange}
-                    className="mt-2 w-full rounded-xl border-2 border-indigo-100 bg-white px-4 py-3 font-semibold text-slate-800 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                    className="mt-2 w-full rounded-xl border-2 border-spuncast-navy/10 bg-white px-4 py-3 font-semibold text-slate-800 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                   >
                     <option value="">Select Product</option>
                     {Object.entries(productFamilyGroups).map(([family, familyTemplates]) => {
@@ -959,7 +959,7 @@ export default function BlastExitMeasurement() {
                           </ul>
                         )}
                         {selectedSpec.special_requirements && (
-                          <p className="mt-3 rounded-xl bg-indigo-50 p-3 text-sm text-indigo-700">
+                          <p className="mt-3 rounded-xl bg-spuncast-sky p-3 text-sm text-spuncast-navy">
                             Special Requirements: {selectedSpec.special_requirements}
                           </p>
                         )}
@@ -986,7 +986,7 @@ export default function BlastExitMeasurement() {
                           </span>
                         )}
                         {selectedSpec.volume_classification && (
-                          <span className="rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">
+                          <span className="rounded-full bg-spuncast-navy/10 px-3 py-1 text-xs font-semibold text-spuncast-navy">
                             {selectedSpec.volume_classification} Volume
                           </span>
                         )}
@@ -1009,7 +1009,7 @@ export default function BlastExitMeasurement() {
                         value={formData.heatNumber}
                         onChange={handleFieldChange}
                         placeholder="Enter heat number"
-                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                       />
                     </div>
                     <div>
@@ -1024,7 +1024,7 @@ export default function BlastExitMeasurement() {
                         value={formData.operator}
                         onChange={handleFieldChange}
                         placeholder="Your name"
-                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                       />
                     </div>
                   </div>
@@ -1040,7 +1040,7 @@ export default function BlastExitMeasurement() {
                         value={formData.trackingNumber}
                         onChange={handleFieldChange}
                         placeholder="Optional"
-                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                       />
                     </div>
                     <div>
@@ -1052,7 +1052,7 @@ export default function BlastExitMeasurement() {
                         name="shift"
                         value={formData.shift}
                         onChange={handleFieldChange}
-                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                       >
                         <option value="">Select Shift</option>
                         <option value="1">1st Shift</option>
@@ -1067,29 +1067,29 @@ export default function BlastExitMeasurement() {
                   <button
                     type="button"
                     onClick={quickFillHeat}
-                    className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-600"
+                    className="rounded-full bg-spuncast-navy px-4 py-2 text-sm font-semibold text-white transition hover:bg-spuncast-navyDark"
                   >
                     ⚡ Quick Heat#
                   </button>
                   <button
                     type="button"
                     onClick={loadLastMeasurement}
-                    className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-600"
+                    className="rounded-full bg-spuncast-navy px-4 py-2 text-sm font-semibold text-white transition hover:bg-spuncast-navyDark"
                   >
                     🔄 Load Last
                   </button>
                   <button
                     type="button"
                     onClick={showInstructions}
-                    className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-600"
+                    className="rounded-full bg-spuncast-navy px-4 py-2 text-sm font-semibold text-white transition hover:bg-spuncast-navyDark"
                   >
                     📖 Instructions
                   </button>
                 </section>
 
                 {isCylinder && cylinderMeasurements.length > 0 && (
-                  <section className="rounded-2xl border-l-4 border-indigo-400 bg-slate-50 p-6">
-                    <h3 className="text-xl font-semibold text-indigo-500">{cylinderSectionTitle}</h3>
+                  <section className="rounded-2xl border-l-4 border-spuncast-navy bg-slate-50 p-6">
+                    <h3 className="text-xl font-semibold text-spuncast-navy">{cylinderSectionTitle}</h3>
                     <p className="mt-2 text-sm italic text-slate-600">
                       {selectedSpec?.measurement_instructions || 'Use Pi tape for ODs, calipers for lengths.'}
                     </p>
@@ -1120,7 +1120,7 @@ export default function BlastExitMeasurement() {
                                 value={formData[measurement.key]}
                                 onChange={handleFieldChange}
                                 placeholder={hasTarget ? measurement.target.toFixed(4) : '0.0000'}
-                                className={`mt-1 w-full rounded-xl border-2 px-4 py-3 text-center text-lg font-semibold transition focus:outline-none focus:ring-4 focus:ring-indigo-100 ${styles.input}`}
+                                className={`mt-1 w-full rounded-xl border-2 px-4 py-3 text-center text-lg font-semibold transition focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20 ${styles.input}`}
                               />
                             </div>
                             <div className="flex justify-end">{renderStatusBadge(statusKey)}</div>
@@ -1132,8 +1132,8 @@ export default function BlastExitMeasurement() {
                 )}
 
                 {!isCylinder && formData.productNumber && (
-                  <section className="rounded-2xl border-l-4 border-indigo-400 bg-slate-50 p-6">
-                    <h3 className="text-xl font-semibold text-indigo-500">
+                  <section className="rounded-2xl border-l-4 border-spuncast-navy bg-slate-50 p-6">
+                    <h3 className="text-xl font-semibold text-spuncast-navy">
                       {formData.productNumber === 'OTHER'
                         ? 'Standard Measurements'
                         : `${formData.productNumber} Measurements`}
@@ -1162,7 +1162,7 @@ export default function BlastExitMeasurement() {
                                   handleMeasurementChange('odMeasurements', index, event.target.value)
                                 }
                                 placeholder="0.0000"
-                                className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                                className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                               />
                             </div>
                           )
@@ -1185,7 +1185,7 @@ export default function BlastExitMeasurement() {
                                   handleMeasurementChange('idMeasurements', index, event.target.value)
                                 }
                                 placeholder="0.0000"
-                                className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                                className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                               />
                             </div>
                           )
@@ -1208,7 +1208,7 @@ export default function BlastExitMeasurement() {
                                   handleMeasurementChange('lengthMeasurements', index, event.target.value)
                                 }
                                 placeholder="0.0000"
-                                className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                                className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                               />
                             </div>
                           )
@@ -1222,8 +1222,8 @@ export default function BlastExitMeasurement() {
                   </section>
                 )}
 
-                <section className="rounded-2xl border-l-4 border-indigo-400 bg-slate-50 p-6">
-                  <h3 className="text-xl font-semibold text-indigo-500">Quality Assessment</h3>
+                <section className="rounded-2xl border-l-4 border-spuncast-navy bg-slate-50 p-6">
+                  <h3 className="text-xl font-semibold text-spuncast-navy">Quality Assessment</h3>
                   <div className="mt-4 grid gap-4 sm:grid-cols-2">
                     <div>
                       <label className="block text-sm font-semibold text-slate-700" htmlFor="materialAppearance">
@@ -1234,7 +1234,7 @@ export default function BlastExitMeasurement() {
                         name="materialAppearance"
                         value={formData.materialAppearance}
                         onChange={handleFieldChange}
-                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                       >
                         <option value="">Select Condition</option>
                         <option value="EXCELLENT">Excellent - Perfect Cast</option>
@@ -1253,7 +1253,7 @@ export default function BlastExitMeasurement() {
                         required
                         value={formData.dimensionalStatus}
                         onChange={handleFieldChange}
-                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                       >
                         <option value="PASS">✅ PASS - All dimensions OK</option>
                         <option value="MARGINAL">⚠️ MARGINAL - Close to limits</option>
@@ -1270,7 +1270,7 @@ export default function BlastExitMeasurement() {
                         required
                         value={formData.heatTreatApproved}
                         onChange={handleFieldChange}
-                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                       >
                         <option value="true">✅ APPROVED - Send to Heat Treat</option>
                         <option value="false">❌ REJECTED - Hold/Scrap</option>
@@ -1285,7 +1285,7 @@ export default function BlastExitMeasurement() {
                         name="surfaceCondition"
                         value={formData.surfaceCondition}
                         onChange={handleFieldChange}
-                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                        className="mt-2 w-full rounded-xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                       >
                         <option value="">Select Condition</option>
                         <option value="SMOOTH">Smooth - No Issues</option>
@@ -1309,7 +1309,7 @@ export default function BlastExitMeasurement() {
                     value={formData.notes}
                     onChange={handleFieldChange}
                     placeholder="Record observations about casting quality, measurement issues, or recommendations..."
-                    className="mt-2 w-full rounded-2xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-indigo-100"
+                    className="mt-2 w-full rounded-2xl border-2 border-slate-200 px-4 py-3 focus:outline-none focus:ring-4 focus:ring-spuncast-navy/20"
                   />
                 </section>
 
@@ -1317,7 +1317,7 @@ export default function BlastExitMeasurement() {
                   <button
                     type="submit"
                     disabled={isSubmitting}
-                    className="w-full rounded-full bg-gradient-to-r from-indigo-500 to-purple-500 px-6 py-4 text-lg font-semibold uppercase tracking-wide text-white shadow-lg transition hover:shadow-xl disabled:cursor-not-allowed disabled:from-slate-300 disabled:to-slate-400"
+                    className="w-full rounded-full bg-gradient-to-r from-spuncast-navy to-spuncast-red px-6 py-4 text-lg font-semibold uppercase tracking-wide text-white shadow-lg transition hover:shadow-xl disabled:cursor-not-allowed disabled:from-slate-300 disabled:to-slate-400"
                   >
                     {isSubmitting ? '⏳ Submitting...' : '📏 Submit Measurement'}
                   </button>

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -84,58 +84,58 @@ const ToolChangesTable = ({ toolChanges = [] }) => {
   const mappedData = toolChanges.map(mapToolChangeForDisplay)
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border overflow-hidden">
-      <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-        <h3 className="text-lg font-semibold text-gray-900">Recent Tool Changes</h3>
-        <span className="text-sm text-gray-500">{toolChanges.length} records</span>
+    <div className="rounded-3xl border border-white/60 bg-white shadow-brand overflow-hidden">
+      <div className="border-b border-spuncast-navy/10 px-6 py-4 flex justify-between items-center">
+        <h3 className="text-lg font-semibold text-spuncast-navy">Recent Tool Changes</h3>
+        <span className="text-sm text-spuncast-slate/70">{toolChanges.length} records</span>
       </div>
 
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-spuncast-navy/10">
+          <thead className="bg-spuncast-sky">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-spuncast-slate/70 uppercase tracking-wider">
                 Date/Time
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-spuncast-slate/70 uppercase tracking-wider">
                 Operator
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-spuncast-slate/70 uppercase tracking-wider">
                 Equipment
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-spuncast-slate/70 uppercase tracking-wider">
                 1st Rougher
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-spuncast-slate/70 uppercase tracking-wider">
                 Finish Tool
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-spuncast-slate/70 uppercase tracking-wider">
                 Reason
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-spuncast-slate/70 uppercase tracking-wider">
                 Downtime
               </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th className="px-4 py-3 text-left text-xs font-medium text-spuncast-slate/70 uppercase tracking-wider">
                 Cost
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-white divide-y divide-spuncast-navy/10">
             {mappedData.map((change, index) => (
-              <tr key={change.id || index} className="hover:bg-gray-50">
-                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+              <tr key={change.id || index} className="hover:bg-spuncast-sky">
+                <td className="px-4 py-3 whitespace-nowrap text-sm text-spuncast-navy">
                   <div>
                     <div className="font-medium">{change.date}</div>
-                    <div className="text-gray-500">{change.time}</div>
+                    <div className="text-spuncast-slate/70">{change.time}</div>
                   </div>
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm">
-                  <div className={`font-medium ${change.operator !== 'N/A' ? 'text-gray-900' : 'text-gray-400'}`}>
+                  <div className={`font-medium ${change.operator !== 'N/A' ? 'text-spuncast-navy' : 'text-spuncast-slate/50'}`}>
                     {change.operator}
                   </div>
                 </td>
                 <td className="px-4 py-3 whitespace-nowrap text-sm">
-                  <div className={`font-medium ${change.equipment !== 'N/A' ? 'text-gray-900' : 'text-gray-400'}`}>
+                  <div className={`font-medium ${change.equipment !== 'N/A' ? 'text-spuncast-navy' : 'text-spuncast-slate/50'}`}>
                     {change.equipment}
                   </div>
                 </td>
@@ -143,8 +143,8 @@ const ToolChangesTable = ({ toolChanges = [] }) => {
                   <span
                     className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
                       change.firstRougher !== 'N/A'
-                        ? 'bg-blue-100 text-blue-800'
-                        : 'bg-gray-100 text-gray-500'
+                        ? 'bg-spuncast-navy/10 text-spuncast-navy'
+                        : 'bg-spuncast-sky text-spuncast-slate/70'
                     }`}
                   >
                     {change.firstRougher}
@@ -154,20 +154,20 @@ const ToolChangesTable = ({ toolChanges = [] }) => {
                   <span
                     className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
                       change.finishTool !== 'N/A'
-                        ? 'bg-green-100 text-green-800'
-                        : 'bg-gray-100 text-gray-500'
+                        ? 'bg-spuncast-red/10 text-spuncast-red'
+                        : 'bg-spuncast-sky text-spuncast-slate/70'
                     }`}
                   >
                     {change.finishTool}
                   </span>
                 </td>
-                <td className="px-4 py-3 text-sm text-gray-900 max-w-xs truncate">
+                <td className="px-4 py-3 text-sm text-spuncast-navy max-w-xs truncate">
                   {change.changeReason}
                 </td>
-                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                <td className="px-4 py-3 whitespace-nowrap text-sm text-spuncast-navy">
                   {change.downtime !== 'N/A' ? `${change.downtime} min` : 'N/A'}
                 </td>
-                <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                <td className="px-4 py-3 whitespace-nowrap text-sm text-spuncast-navy">
                   {change.totalCost > 0 ? `$${change.totalCost.toFixed(2)}` : 'N/A'}
                 </td>
               </tr>
@@ -177,9 +177,9 @@ const ToolChangesTable = ({ toolChanges = [] }) => {
       </div>
 
       {toolChanges.length === 0 && (
-        <div className="text-center py-12 text-gray-500">
+        <div className="text-center py-12 text-spuncast-slate/70">
           <div className="text-lg mb-2">No tool changes recorded yet</div>
-          <Link href="/tool-change-form" className="text-blue-600 hover:text-blue-500">
+          <Link href="/tool-change-form" className="text-spuncast-navy hover:text-spuncast-red">
             Add your first tool change →
           </Link>
         </div>
@@ -237,7 +237,7 @@ export default function Dashboard() {
   })
 
   // Chart colors
-  const colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#06B6D4']
+  const colors = ['#003865', '#E41E2B', '#5A7AA4', '#B0171F', '#7A94B8', '#F36F6F']
 
   useEffect(() => {
     debugToolChangeData()
@@ -354,144 +354,145 @@ export default function Dashboard() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="flex items-center space-x-2">
-          <RefreshCw className="animate-spin h-6 w-6 text-blue-600" />
-          <span className="text-lg text-gray-600">Loading dashboard...</span>
+      <div className="flex min-h-screen items-center justify-center bg-spuncast-sky">
+        <div className="flex items-center space-x-3 rounded-full bg-white/80 px-6 py-3 shadow-brand">
+          <RefreshCw className="h-6 w-6 animate-spin text-spuncast-navy" />
+          <span className="text-lg font-medium text-spuncast-slate">Loading dashboard...</span>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gradient-to-b from-spuncast-navy/10 via-spuncast-sky to-white">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 py-4">
-          <div className="flex justify-between items-center">
-            <div className="flex items-center space-x-4">
-              <Link href="/" className="flex items-center space-x-2 text-gray-600 hover:text-gray-900">
-                <ArrowLeft size={20} />
-                <span>Back to Form</span>
-              </Link>
-              <h1 className="text-3xl font-bold text-gray-900">📊 Manufacturing Analytics Dashboard</h1>
-            </div>
-            <div className="flex items-center space-x-4">
-              <select
-                value={selectedDateRange}
-                onChange={(e) => setSelectedDateRange(Number(e.target.value))}
-                className="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value={7}>Last 7 days</option>
-                <option value={30}>Last 30 days</option>
-                <option value={90}>Last 90 days</option>
-              </select>
-              <button
-                onClick={loadDashboardData}
-                className="flex items-center space-x-2 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
-              >
-                <RefreshCw size={16} />
-                <span>Refresh</span>
-              </button>
-            </div>
+      <header className="border-b border-spuncast-navy/10 bg-white/90 shadow-sm backdrop-blur">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-5 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-4">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-full border border-spuncast-navy/20 px-4 py-2 text-sm font-medium text-spuncast-navy transition hover:border-spuncast-red/40 hover:text-spuncast-red"
+            >
+              <ArrowLeft size={18} />
+              <span>Back to Tool Change Form</span>
+            </Link>
+            <h1 className="text-2xl font-bold text-spuncast-navy sm:text-3xl">📊 Manufacturing Analytics Dashboard</h1>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <select
+              value={selectedDateRange}
+              onChange={(e) => setSelectedDateRange(Number(e.target.value))}
+              className="rounded-full border border-spuncast-navy/10 bg-white px-4 py-2 text-sm font-medium text-spuncast-slate focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+            >
+              <option value={7}>Last 7 days</option>
+              <option value={30}>Last 30 days</option>
+              <option value={90}>Last 90 days</option>
+            </select>
+            <button
+              onClick={loadDashboardData}
+              className="inline-flex items-center gap-2 rounded-full bg-spuncast-red px-5 py-2 text-sm font-semibold text-white shadow-brand transition hover:bg-spuncast-redDark"
+            >
+              <RefreshCw size={16} className="animate-spin" />
+              <span>Refresh</span>
+            </button>
           </div>
         </div>
       </header>
 
-      <div className="max-w-7xl mx-auto px-4 py-8 space-y-8">
+      <div className="mx-auto max-w-7xl space-y-8 px-4 py-8">
         {/* Quick Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Tool Changes Today</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.todayChanges}</p>
+                <p className="text-sm font-semibold text-spuncast-slate">Tool Changes Today</p>
+                <p className="text-2xl font-bold text-spuncast-navy">{stats.todayChanges}</p>
               </div>
-              <TrendingUp className="h-8 w-8 text-blue-600" />
+              <TrendingUp className="h-8 w-8 text-spuncast-navy" />
             </div>
           </div>
 
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Active Machines</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.activeMachines}</p>
+                <p className="text-sm font-semibold text-spuncast-slate">Active Machines</p>
+                <p className="text-2xl font-bold text-spuncast-navy">{stats.activeMachines}</p>
               </div>
-              <Settings className="h-8 w-8 text-green-600" />
+              <Settings className="h-8 w-8 text-spuncast-red" />
             </div>
           </div>
 
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Cost Savings</p>
-                <p className="text-2xl font-bold text-gray-900">${stats.costSavings}</p>
+                <p className="text-sm font-semibold text-spuncast-slate">Cost Savings</p>
+                <p className="text-2xl font-bold text-spuncast-navy">${stats.costSavings}</p>
               </div>
-              <Database className="h-8 w-8 text-purple-600" />
+              <Database className="h-8 w-8 text-spuncast-navy" />
             </div>
           </div>
 
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Efficiency</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.efficiency}%</p>
+                <p className="text-sm font-semibold text-spuncast-slate">Efficiency</p>
+                <p className="text-2xl font-bold text-spuncast-navy">{stats.efficiency}%</p>
               </div>
-              <BarChart3 className="h-8 w-8 text-orange-600" />
+              <BarChart3 className="h-8 w-8 text-spuncast-red" />
             </div>
           </div>
         </div>
 
         {/* Key Metrics Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Total Tool Changes</p>
-                <p className="text-3xl font-bold text-gray-900">{analytics?.totalChanges || 0}</p>
-                <p className="text-sm text-gray-500">Last {selectedDateRange} days</p>
+                <p className="text-sm font-semibold text-spuncast-slate">Total Tool Changes</p>
+                <p className="text-3xl font-bold text-spuncast-navy">{analytics?.totalChanges || 0}</p>
+                <p className="text-sm text-spuncast-slate/70">Last {selectedDateRange} days</p>
               </div>
-              <Wrench className="h-12 w-12 text-blue-600" />
+              <Wrench className="h-12 w-12 text-spuncast-navy" />
             </div>
           </div>
 
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Average Downtime</p>
-                <p className="text-3xl font-bold text-gray-900">{analytics?.averageDowntime || 0}</p>
-                <p className="text-sm text-gray-500">Minutes per change</p>
+                <p className="text-sm font-semibold text-spuncast-slate">Average Downtime</p>
+                <p className="text-3xl font-bold text-spuncast-navy">{analytics?.averageDowntime || 0}</p>
+                <p className="text-sm text-spuncast-slate/70">Minutes per change</p>
               </div>
-              <Clock className="h-12 w-12 text-orange-600" />
+              <Clock className="h-12 w-12 text-spuncast-red" />
             </div>
           </div>
 
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Total Cost Impact</p>
-                <p className="text-3xl font-bold text-gray-900">${costAnalysis?.totalCost || 0}</p>
-                <p className="text-sm text-gray-500">Insert + downtime costs</p>
+                <p className="text-sm font-semibold text-spuncast-slate">Total Cost Impact</p>
+                <p className="text-3xl font-bold text-spuncast-navy">${costAnalysis?.totalCost || 0}</p>
+                <p className="text-sm text-spuncast-slate/70">Insert + downtime costs</p>
               </div>
-              <DollarSign className="h-12 w-12 text-green-600" />
+              <DollarSign className="h-12 w-12 text-spuncast-red" />
             </div>
           </div>
 
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-600">Active Operators</p>
-                <p className="text-3xl font-bold text-gray-900">{Object.keys(analytics?.operatorPerformance || {}).length}</p>
-                <p className="text-sm text-gray-500">Recording changes</p>
+                <p className="text-sm font-semibold text-spuncast-slate">Active Operators</p>
+                <p className="text-3xl font-bold text-spuncast-navy">{Object.keys(analytics?.operatorPerformance || {}).length}</p>
+                <p className="text-sm text-spuncast-slate/70">Recording changes</p>
               </div>
-              <Users className="h-12 w-12 text-purple-600" />
+              <Users className="h-12 w-12 text-spuncast-navy" />
             </div>
           </div>
         </div>
 
         {/* Timeline Chart */}
-        <div className="bg-white p-6 rounded-lg shadow-sm border">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">Tool Changes Over Time</h2>
+        <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+          <h2 className="text-xl font-semibold text-spuncast-navy mb-4">Tool Changes Over Time</h2>
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={timelineData}>
@@ -501,12 +502,12 @@ export default function Dashboard() {
                 <YAxis yAxisId="right" orientation="right" />
                 <Tooltip />
                 <Legend />
-                <Bar yAxisId="left" dataKey="changes" fill="#3B82F6" name="Tool Changes" />
+                <Bar yAxisId="left" dataKey="changes" fill="#003865" name="Tool Changes" />
                 <Line 
                   yAxisId="right" 
                   type="monotone" 
                   dataKey="downtime" 
-                  stroke="#EF4444" 
+                  stroke="#E41E2B" 
                   strokeWidth={2}
                   name="Total Downtime (min)"
                 />
@@ -518,8 +519,8 @@ export default function Dashboard() {
         {/* Two-column layout */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
           {/* Change Reasons */}
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Change Reasons</h2>
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+            <h2 className="text-xl font-semibold text-spuncast-navy mb-4">Change Reasons</h2>
             <div className="h-80">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={reasonData} layout="horizontal">
@@ -527,15 +528,15 @@ export default function Dashboard() {
                   <XAxis type="number" />
                   <YAxis dataKey="reason" type="category" width={100} />
                   <Tooltip formatter={(value, name, props) => [value, props.payload.fullReason]} />
-                  <Bar dataKey="count" fill="#10B981" />
+                  <Bar dataKey="count" fill="#E41E2B" />
                 </BarChart>
               </ResponsiveContainer>
             </div>
           </div>
 
           {/* Insert Usage */}
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Insert Usage Distribution</h2>
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+            <h2 className="text-xl font-semibold text-spuncast-navy mb-4">Insert Usage Distribution</h2>
             <div className="h-80">
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
@@ -546,7 +547,7 @@ export default function Dashboard() {
                     labelLine={false}
                     label={({ name, percent }) => `${name} (${(percent * 100).toFixed(0)}%)`}
                     outerRadius={80}
-                    fill="#8884d8"
+                    fill="#003865"
                     dataKey="value"
                   >
                     {insertData.map((entry, index) => (
@@ -561,8 +562,8 @@ export default function Dashboard() {
         </div>
 
         {/* Operator Performance */}
-        <div className="bg-white p-6 rounded-lg shadow-sm border">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">Operator Performance Analysis</h2>
+        <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+          <h2 className="text-xl font-semibold text-spuncast-navy mb-4">Operator Performance Analysis</h2>
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={operatorData}>
@@ -572,9 +573,9 @@ export default function Dashboard() {
                 <YAxis yAxisId="right" orientation="right" />
                 <Tooltip />
                 <Legend />
-                <Bar yAxisId="left" dataKey="changes" fill="#3B82F6" name="Total Changes" />
-                <Bar yAxisId="left" dataKey="avgPieces" fill="#10B981" name="Avg Pieces per Change" />
-                <Bar yAxisId="right" dataKey="avgDowntime" fill="#F59E0B" name="Avg Downtime (min)" />
+                <Bar yAxisId="left" dataKey="changes" fill="#003865" name="Total Changes" />
+                <Bar yAxisId="left" dataKey="avgPieces" fill="#E41E2B" name="Avg Pieces per Change" />
+                <Bar yAxisId="right" dataKey="avgDowntime" fill="#7A94B8" name="Avg Downtime (min)" />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -582,24 +583,24 @@ export default function Dashboard() {
 
         {/* Cost Analysis */}
         {costAnalysis && (
-          <div className="bg-white p-6 rounded-lg shadow-sm border">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Cost Analysis Summary</h2>
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+            <h2 className="text-xl font-semibold text-spuncast-navy mb-4">Cost Analysis Summary</h2>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-              <div className="text-center p-4 bg-blue-50 rounded-lg">
-                <p className="text-sm text-gray-600">Insert Costs</p>
-                <p className="text-2xl font-bold text-blue-600">${costAnalysis.totalInsertCost}</p>
+              <div className="text-center p-4 bg-spuncast-sky rounded-lg">
+                <p className="text-sm text-spuncast-slate">Insert Costs</p>
+                <p className="text-2xl font-bold text-spuncast-navy">${costAnalysis.totalInsertCost}</p>
               </div>
-              <div className="text-center p-4 bg-red-50 rounded-lg">
-                <p className="text-sm text-gray-600">Downtime Costs</p>
-                <p className="text-2xl font-bold text-red-600">${costAnalysis.totalDowntimeCost}</p>
+              <div className="text-center p-4 bg-spuncast-red/10 rounded-lg">
+                <p className="text-sm text-spuncast-slate">Downtime Costs</p>
+                <p className="text-2xl font-bold text-spuncast-red">${costAnalysis.totalDowntimeCost}</p>
               </div>
-              <div className="text-center p-4 bg-green-50 rounded-lg">
-                <p className="text-sm text-gray-600">Avg Cost/Change</p>
-                <p className="text-2xl font-bold text-green-600">${costAnalysis.averageCostPerChange}</p>
+              <div className="text-center p-4 bg-spuncast-navy/10 rounded-lg">
+                <p className="text-sm text-spuncast-slate">Avg Cost/Change</p>
+                <p className="text-2xl font-bold text-spuncast-red">${costAnalysis.averageCostPerChange}</p>
               </div>
-              <div className="text-center p-4 bg-purple-50 rounded-lg">
-                <p className="text-sm text-gray-600">Total Changes</p>
-                <p className="text-2xl font-bold text-purple-600">{costAnalysis.totalChanges}</p>
+              <div className="text-center p-4 bg-spuncast-sky rounded-lg">
+                <p className="text-sm text-spuncast-slate">Total Changes</p>
+                <p className="text-2xl font-bold text-spuncast-navy">{costAnalysis.totalChanges}</p>
               </div>
             </div>
           </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,71 +4,85 @@ import { Plus, QrCode, Ruler } from 'lucide-react'
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen">
       {/* Header with Navigation */}
-      <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 py-4">
-          <div className="flex justify-between items-center">
-            <h1 className="text-3xl font-bold text-gray-900">🔧 Tool Change Tracker</h1>
-            <nav className="flex flex-wrap gap-3">
+      <header className="bg-white/95 backdrop-blur border-b border-spuncast-navy/10 shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 py-5">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="flex items-center gap-4">
+              <img
+                src="/spuncast-logo.svg"
+                alt="Spuncast logo"
+                className="h-14 w-auto drop-shadow-sm"
+              />
+              <div>
+                <p className="text-sm uppercase tracking-[0.3em] text-spuncast-red font-semibold">Tooling Excellence</p>
+                <h1 className="text-3xl font-bold text-spuncast-navy">Tool Change Tracker</h1>
+              </div>
+            </div>
+            <nav className="flex flex-wrap gap-3 text-sm font-semibold">
               <Link
                 href="/blast-exit"
-                className="flex items-center space-x-2 bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
+                className="group inline-flex items-center gap-2 rounded-full bg-spuncast-navy px-5 py-2.5 text-white shadow-brand transition hover:bg-spuncast-navyDark"
               >
-                <Ruler size={20} />
+                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-white">
+                  <Ruler size={18} />
+                </span>
                 <span>Blast Exit Measurements</span>
               </Link>
               <Link
                 href="/qr-generator"
-                className="flex items-center space-x-2 bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors"
+                className="group inline-flex items-center gap-2 rounded-full bg-spuncast-red px-5 py-2.5 text-white shadow-brand transition hover:bg-spuncast-redDark"
               >
-                <QrCode size={20} />
+                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-white">
+                  <QrCode size={18} />
+                </span>
                 <span>QR Generator</span>
               </Link>
             </nav>
           </div>
         </div>
       </header>
-      <div className="max-w-7xl mx-auto px-4 py-8">
-        {/* Action Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-8">
-          <div className="bg-gradient-to-r from-green-500 to-green-600 p-6 rounded-lg text-white">
-            <div className="flex items-center space-x-3">
-              <Plus size={32} />
+      <div className="max-w-7xl mx-auto px-4 py-10">
+        <section className="mb-10 grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+          <div className="rounded-2xl bg-white shadow-brand border border-white/60 p-6">
+            <div className="flex items-start gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-spuncast-red to-spuncast-redDark text-white shadow-brand">
+                <Plus size={28} />
+              </div>
               <div>
-                <h3 className="text-xl font-semibold">Record Tool Change</h3>
-                <p className="text-green-100">Log new tool changes below</p>
+                <h3 className="text-xl font-semibold text-spuncast-navy">Record Tool Change</h3>
+                <p className="text-sm text-spuncast-slate/70">Log the details of your latest tool swap in the form below.</p>
               </div>
             </div>
           </div>
 
-          <Link href="/blast-exit" className="group">
-            <div className="bg-gradient-to-r from-indigo-500 to-indigo-600 p-6 rounded-lg text-white hover:from-indigo-600 hover:to-indigo-700 transition-all transform group-hover:scale-105">
-              <div className="flex items-center space-x-3">
-                <Ruler size={32} />
-                <div>
-                  <h3 className="text-xl font-semibold">Blast Exit Measurements</h3>
-                  <p className="text-indigo-100">Capture casting inspection data</p>
-                </div>
+          <Link href="/blast-exit" className="group rounded-2xl bg-gradient-to-br from-spuncast-navy to-spuncast-navyDark p-6 text-white shadow-brand transition-transform hover:-translate-y-1">
+            <div className="flex items-start gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white">
+                <Ruler size={28} />
+              </div>
+              <div>
+                <h3 className="text-xl font-semibold">Blast Exit Measurements</h3>
+                <p className="text-sm text-white/80">Capture casting inspection data with brand-aligned visuals.</p>
               </div>
             </div>
           </Link>
 
-          <Link href="/qr-generator" className="group">
-            <div className="bg-gradient-to-r from-purple-500 to-purple-600 p-6 rounded-lg text-white hover:from-purple-600 hover:to-purple-700 transition-all transform group-hover:scale-105">
-              <div className="flex items-center space-x-3">
-                <QrCode size={32} />
-                <div>
-                  <h3 className="text-xl font-semibold">Generate QR Codes</h3>
-                  <p className="text-purple-100">Create equipment QR codes</p>
-                </div>
+          <Link href="/qr-generator" className="group rounded-2xl bg-gradient-to-br from-spuncast-red to-spuncast-redDark p-6 text-white shadow-brand transition-transform hover:-translate-y-1">
+            <div className="flex items-start gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white">
+                <QrCode size={28} />
+              </div>
+              <div>
+                <h3 className="text-xl font-semibold">Generate QR Codes</h3>
+                <p className="text-sm text-white/80">Produce equipment QR codes that match Spuncast branding.</p>
               </div>
             </div>
           </Link>
-        </div>
+        </section>
 
-        {/* Tool Change Form */}
-        <div className="bg-white rounded-lg shadow-sm border">
+        <div className="rounded-3xl border border-white/60 bg-white shadow-brand">
           <ToolChangeForm />
         </div>
       </div>

--- a/pages/qr-generator.js
+++ b/pages/qr-generator.js
@@ -376,21 +376,21 @@ const QRGeneratorPage = () => {
         <title>QR Code Generator</title>
       </Head>
 
-      <div className="min-h-screen bg-gradient-to-br from-indigo-500 to-purple-600 p-6">
-        <div className="mx-auto max-w-5xl rounded-3xl bg-white p-8 shadow-2xl">
+      <div className="min-h-screen bg-gradient-to-br from-spuncast-navy via-spuncast-navyDark to-spuncast-red p-6">
+        <div className="mx-auto max-w-5xl rounded-3xl border border-white/60 bg-white p-8 shadow-brand">
           <div className="text-center">
-            <h1 className="text-3xl font-bold text-indigo-600">🏷️ QR Code Generator</h1>
-            <p className="mt-2 text-gray-600">Generate QR codes for equipment and custom URLs</p>
+            <h1 className="text-3xl font-bold text-spuncast-navy">🏷️ QR Code Generator</h1>
+            <p className="mt-2 text-spuncast-slate/80">Generate QR codes for equipment and custom URLs</p>
           </div>
 
-          <div className="mt-8 rounded-xl bg-indigo-50 p-2">
-            <div className="grid grid-cols-2 gap-2 text-sm font-semibold text-indigo-500">
+          <div className="mt-8 rounded-xl bg-spuncast-sky p-2">
+            <div className="grid grid-cols-2 gap-2 text-sm font-semibold text-spuncast-navy">
               <button
                 type="button"
                 className={`rounded-lg px-4 py-3 transition-all ${
                   activeTab === 'equipment'
-                    ? 'bg-indigo-500 text-white shadow'
-                    : 'hover:bg-indigo-100'
+                    ? 'bg-spuncast-navy text-white shadow'
+                    : 'hover:bg-spuncast-sky/80'
                 }`}
                 onClick={() => setActiveTab('equipment')}
               >
@@ -400,8 +400,8 @@ const QRGeneratorPage = () => {
                 type="button"
                 className={`rounded-lg px-4 py-3 transition-all ${
                   activeTab === 'custom'
-                    ? 'bg-indigo-500 text-white shadow'
-                    : 'hover:bg-indigo-100'
+                    ? 'bg-spuncast-navy text-white shadow'
+                    : 'hover:bg-spuncast-sky/80'
                 }`}
                 onClick={() => setActiveTab('custom')}
               >
@@ -419,7 +419,7 @@ const QRGeneratorPage = () => {
           <div className="mt-6">
             <section className={activeTab === 'equipment' ? 'block' : 'hidden'}>
               {loading ? (
-                <div className="rounded-2xl bg-indigo-50 p-10 text-center text-indigo-600">
+                <div className="rounded-2xl bg-spuncast-sky p-10 text-center text-spuncast-navy">
                   🔄 Loading equipment from database...
                 </div>
               ) : error ? (
@@ -429,7 +429,7 @@ const QRGeneratorPage = () => {
               ) : (
                 <div className="space-y-6">
                   <div>
-                    <label htmlFor="equipmentFilter" className="block text-sm font-semibold text-gray-700">
+                    <label htmlFor="equipmentFilter" className="block text-sm font-semibold text-spuncast-slate">
                       Filter Equipment
                     </label>
                     <input
@@ -438,13 +438,13 @@ const QRGeneratorPage = () => {
                       value={filter}
                       onChange={event => setFilter(event.target.value)}
                       placeholder="Search by equipment number, description, or work center..."
-                      className="mt-2 w-full rounded-xl border-2 border-indigo-100 p-3 text-sm shadow-sm transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+                      className="mt-2 w-full rounded-xl border-2 border-spuncast-navy/10 p-3 text-sm shadow-sm transition focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
                     />
                   </div>
 
                   <div className="space-y-3">
                     {filteredEquipment.length === 0 ? (
-                      <p className="rounded-2xl bg-indigo-50 p-6 text-center text-sm text-indigo-500">
+                      <p className="rounded-2xl bg-spuncast-sky p-6 text-center text-sm text-spuncast-navy">
                         No active equipment found.
                       </p>
                     ) : (
@@ -459,20 +459,20 @@ const QRGeneratorPage = () => {
                             onClick={() => handleSelectEquipment(item)}
                             className={`w-full rounded-2xl border-2 p-4 text-left transition-all ${
                               isSelected
-                                ? 'border-indigo-400 bg-indigo-50 shadow'
-                                : 'border-indigo-100 bg-white hover:-translate-y-0.5 hover:border-indigo-300 hover:shadow'
+                                ? 'border-spuncast-navy bg-spuncast-sky shadow'
+                                : 'border-spuncast-navy/10 bg-white hover:-translate-y-0.5 hover:border-spuncast-navy/40 hover:shadow'
                             }`}
                           >
                             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                               <div>
-                                <h3 className="text-lg font-semibold text-gray-800">
+                                <h3 className="text-lg font-semibold text-spuncast-navy">
                                   {item.equipment_number} - {item.description}
                                 </h3>
-                                <p className="text-sm text-gray-600">
+                                <p className="text-sm text-spuncast-slate/80">
                                   Work Center: {item.work_center || 'N/A'} | Type: {item.equipment_type || 'N/A'} | Location: {item.location || 'N/A'}
                                 </p>
                               </div>
-                              <div className="text-right text-xs text-gray-500 sm:text-sm">
+                              <div className="text-right text-xs text-spuncast-slate/70 sm:text-sm">
                                 <div className={statusClass}>{item.status || 'ACTIVE'}</div>
                                 <div>ID: {item.id}</div>
                               </div>
@@ -484,24 +484,24 @@ const QRGeneratorPage = () => {
                   </div>
 
                   {selectedEquipment && (
-                    <div className="space-y-6 rounded-2xl bg-indigo-50 p-6">
+                    <div className="space-y-6 rounded-2xl bg-spuncast-sky p-6">
                       <div className="rounded-2xl bg-white p-5 shadow-sm">
-                        <h4 className="text-lg font-semibold text-gray-800">{formatEquipmentTitle(selectedEquipment)}</h4>
-                        <dl className="mt-3 grid grid-cols-1 gap-3 text-sm text-gray-600 sm:grid-cols-2">
+                        <h4 className="text-lg font-semibold text-spuncast-navy">{formatEquipmentTitle(selectedEquipment)}</h4>
+                        <dl className="mt-3 grid grid-cols-1 gap-3 text-sm text-spuncast-slate/80 sm:grid-cols-2">
                           <div>
-                            <dt className="font-medium text-gray-700">Work Center</dt>
+                            <dt className="font-medium text-spuncast-slate">Work Center</dt>
                             <dd>{selectedEquipment.work_center || 'N/A'}</dd>
                           </div>
                           <div>
-                            <dt className="font-medium text-gray-700">Type</dt>
+                            <dt className="font-medium text-spuncast-slate">Type</dt>
                             <dd>{selectedEquipment.equipment_type || 'N/A'}</dd>
                           </div>
                           <div>
-                            <dt className="font-medium text-gray-700">Location</dt>
+                            <dt className="font-medium text-spuncast-slate">Location</dt>
                             <dd>{selectedEquipment.location || 'N/A'}</dd>
                           </div>
                           <div>
-                            <dt className="font-medium text-gray-700">Status</dt>
+                            <dt className="font-medium text-spuncast-slate">Status</dt>
                             <dd className={statusColor(selectedEquipment.status)}>{selectedEquipment.status || 'ACTIVE'}</dd>
                           </div>
                         </dl>
@@ -509,14 +509,14 @@ const QRGeneratorPage = () => {
 
                       <div className="grid gap-5 sm:grid-cols-2">
                         <div>
-                          <label htmlFor="qrType" className="block text-sm font-semibold text-gray-700">
+                          <label htmlFor="qrType" className="block text-sm font-semibold text-spuncast-slate">
                             QR Code Type
                           </label>
                           <select
                             id="qrType"
                             value={qrType}
                             onChange={event => setQrType(event.target.value)}
-                            className="mt-2 w-full rounded-xl border-2 border-indigo-100 p-3 text-sm shadow-sm transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+                            className="mt-2 w-full rounded-xl border-2 border-spuncast-navy/10 p-3 text-sm shadow-sm transition focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
                           >
                             <option value="measurement">📏 Measurement App</option>
                             <option value="tool-change">🔧 Tool Change App</option>
@@ -524,7 +524,7 @@ const QRGeneratorPage = () => {
                           </select>
                         </div>
                         <div>
-                          <label htmlFor="baseUrl" className="block text-sm font-semibold text-gray-700">
+                          <label htmlFor="baseUrl" className="block text-sm font-semibold text-spuncast-slate">
                             Base URL
                           </label>
                           <input
@@ -532,14 +532,14 @@ const QRGeneratorPage = () => {
                             type="text"
                             value={baseUrl}
                             onChange={event => setBaseUrl(event.target.value)}
-                            className="mt-2 w-full rounded-xl border-2 border-indigo-100 p-3 text-sm shadow-sm transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+                            className="mt-2 w-full rounded-xl border-2 border-spuncast-navy/10 p-3 text-sm shadow-sm transition focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
                           />
                         </div>
                       </div>
 
                       <button
                         type="button"
-                        className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-indigo-500 to-purple-500 px-6 py-3 font-semibold text-white shadow-lg transition hover:translate-y-[-2px] hover:shadow-xl"
+                        className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-spuncast-navy to-spuncast-red px-6 py-3 font-semibold text-white shadow-lg transition hover:translate-y-[-2px] hover:shadow-xl"
                         onClick={handleGenerateEquipmentQR}
                       >
                         🎯 Generate QR Code
@@ -549,8 +549,8 @@ const QRGeneratorPage = () => {
                         className="rounded-2xl bg-white p-6 text-center shadow-lg"
                         style={{ display: equipmentQrGenerated ? 'block' : 'none' }}
                       >
-                        <h3 className="text-lg font-semibold text-gray-800">{equipmentQrTitle}</h3>
-                        <div className="mt-3 rounded-xl border-2 border-indigo-100 bg-indigo-50 p-3 text-sm text-indigo-600">
+                        <h3 className="text-lg font-semibold text-spuncast-navy">{equipmentQrTitle}</h3>
+                        <div className="mt-3 rounded-xl border-2 border-spuncast-navy/10 bg-spuncast-sky p-3 text-sm text-spuncast-navy">
                           {generatedUrl}
                         </div>
                         <div className="mt-4 flex justify-center">
@@ -559,21 +559,21 @@ const QRGeneratorPage = () => {
                         <div className="mt-5 flex flex-wrap justify-center gap-3">
                           <button
                             type="button"
-                            className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-600"
+                            className="rounded-full bg-spuncast-navy px-4 py-2 text-sm font-semibold text-white shadow hover:bg-spuncast-navyDark"
                             onClick={handleDownloadEquipmentQR}
                           >
                             💾 Download PNG
                           </button>
                           <button
                             type="button"
-                            className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-600"
+                            className="rounded-full bg-spuncast-navy px-4 py-2 text-sm font-semibold text-white shadow hover:bg-spuncast-navyDark"
                             onClick={handlePrintEquipmentQR}
                           >
                             🖨️ Print
                           </button>
                           <button
                             type="button"
-                            className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-600"
+                            className="rounded-full bg-spuncast-navy px-4 py-2 text-sm font-semibold text-white shadow hover:bg-spuncast-navyDark"
                             onClick={handleCopyEquipmentUrl}
                           >
                             📋 Copy URL
@@ -587,9 +587,9 @@ const QRGeneratorPage = () => {
             </section>
 
             <section className={activeTab === 'custom' ? 'block' : 'hidden'}>
-              <div className="space-y-6 rounded-2xl bg-indigo-50 p-6">
+              <div className="space-y-6 rounded-2xl bg-spuncast-sky p-6">
                 <div>
-                  <label htmlFor="customUrl" className="block text-sm font-semibold text-gray-700">
+                  <label htmlFor="customUrl" className="block text-sm font-semibold text-spuncast-slate">
                     Custom URL
                   </label>
                   <input
@@ -601,12 +601,12 @@ const QRGeneratorPage = () => {
                       setCustomQrGenerated(false)
                     }}
                     placeholder="Enter any URL..."
-                    className="mt-2 w-full rounded-xl border-2 border-indigo-100 p-3 text-sm shadow-sm transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+                    className="mt-2 w-full rounded-xl border-2 border-spuncast-navy/10 p-3 text-sm shadow-sm transition focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
                   />
                 </div>
 
                 <div>
-                  <label htmlFor="customTitle" className="block text-sm font-semibold text-gray-700">
+                  <label htmlFor="customTitle" className="block text-sm font-semibold text-spuncast-slate">
                     QR Code Title (optional)
                   </label>
                   <input
@@ -618,13 +618,13 @@ const QRGeneratorPage = () => {
                       setCustomQrGenerated(false)
                     }}
                     placeholder="Title to display with the QR code"
-                    className="mt-2 w-full rounded-xl border-2 border-indigo-100 p-3 text-sm shadow-sm transition focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"
+                    className="mt-2 w-full rounded-xl border-2 border-spuncast-navy/10 p-3 text-sm shadow-sm transition focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
                   />
                 </div>
 
                 <button
                   type="button"
-                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-indigo-500 to-purple-500 px-6 py-3 font-semibold text-white shadow-lg transition hover:translate-y-[-2px] hover:shadow-xl"
+                  className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-spuncast-navy to-spuncast-red px-6 py-3 font-semibold text-white shadow-lg transition hover:translate-y-[-2px] hover:shadow-xl"
                   onClick={handleGenerateCustomQR}
                 >
                   🎯 Generate Custom QR
@@ -634,8 +634,8 @@ const QRGeneratorPage = () => {
                   className="rounded-2xl bg-white p-6 text-center shadow-lg"
                   style={{ display: customQrGenerated ? 'block' : 'none' }}
                 >
-                  <h3 className="text-lg font-semibold text-gray-800">{customQrTitle}</h3>
-                  <div className="mt-3 rounded-xl border-2 border-indigo-100 bg-indigo-50 p-3 text-sm text-indigo-600">
+                  <h3 className="text-lg font-semibold text-spuncast-navy">{customQrTitle}</h3>
+                  <div className="mt-3 rounded-xl border-2 border-spuncast-navy/10 bg-spuncast-sky p-3 text-sm text-spuncast-navy">
                     {customGeneratedUrl}
                   </div>
                   <div className="mt-4 flex justify-center">
@@ -644,21 +644,21 @@ const QRGeneratorPage = () => {
                   <div className="mt-5 flex flex-wrap justify-center gap-3">
                     <button
                       type="button"
-                      className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-600"
+                      className="rounded-full bg-spuncast-navy px-4 py-2 text-sm font-semibold text-white shadow hover:bg-spuncast-navyDark"
                       onClick={handleDownloadCustomQR}
                     >
                       💾 Download PNG
                     </button>
                     <button
                       type="button"
-                      className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-600"
+                      className="rounded-full bg-spuncast-navy px-4 py-2 text-sm font-semibold text-white shadow hover:bg-spuncast-navyDark"
                       onClick={handlePrintCustomQR}
                     >
                       🖨️ Print
                     </button>
                     <button
                       type="button"
-                      className="rounded-full bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-600"
+                      className="rounded-full bg-spuncast-navy px-4 py-2 text-sm font-semibold text-white shadow hover:bg-spuncast-navyDark"
                       onClick={handleCopyCustomUrl}
                     >
                       📋 Copy URL
@@ -670,7 +670,7 @@ const QRGeneratorPage = () => {
           </div>
 
           <div className="mt-8 text-center">
-            <Link href="/" className="font-semibold text-indigo-600 transition hover:text-indigo-800">
+            <Link href="/" className="font-semibold text-spuncast-navy transition hover:text-spuncast-red">
               &larr; Back to Tool Change Form
             </Link>
           </div>

--- a/public/spuncast-logo.svg
+++ b/public/spuncast-logo.svg
@@ -1,0 +1,8 @@
+<svg width="360" height="120" viewBox="0 0 360 120" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Spuncast logo</title>
+  <desc id="desc">Abstract red circular mark with the word Spuncast and address</desc>
+  <path d="M60 18c-23.196 0-42 18.804-42 42s18.804 42 42 42c20.16 0 36.95-13.722 41.104-32H82.632c-3.786 8.536-12.304 14-22.632 14-13.255 0-24-10.745-24-24s10.745-24 24-24c10.328 0 18.846 5.464 22.632 14h18.472C96.95 31.722 80.16 18 60 18z" fill="#E41E2B"/>
+  <path d="M101 33c-1.67 16.848-15.694 30-32.875 30-5.602 0-10.884-1.367-15.51-3.79L48.5 71.57C54.675 75.12 61.999 77 69.875 77c23.196 0 42-18.804 42-42 0-0.685-0.017-1.366-0.05-2.044H101z" fill="#C5131A"/>
+  <text x="128" y="66" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="46" fill="#003865">SPUNCAST</text>
+  <text x="128" y="92" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="500" font-size="16" fill="#003865">W6499 Rhine Road, Watertown, WI 53098</text>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,17 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+  }
+
+  body {
+    @apply bg-spuncast-sky text-spuncast-slate antialiased;
+  }
+
+  a {
+    @apply text-spuncast-navy underline-offset-4 decoration-2 decoration-transparent transition hover:decoration-spuncast-red;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,21 @@ module.exports = {
     './app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        spuncast: {
+          navy: '#003865',
+          navyDark: '#00274E',
+          red: '#E41E2B',
+          redDark: '#B0171F',
+          sky: '#F3F6FB',
+          slate: '#10263F',
+        },
+      },
+      boxShadow: {
+        brand: '0 20px 45px -24px rgba(0, 56, 101, 0.55)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- introduce Spuncast-specific color palette, typography accents, and logo asset for shared styling
- refresh the landing page, tool change form, QR generator, and blast exit workflows with brand-aligned surfaces and calls to action
- re-theme the analytics dashboard and auxiliary data entry screens so charts, cards, and controls follow Spuncast visual language

## Testing
- npm run build *(fails: missing `qrcode` package is unavailable in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4beeb309c832aa140b7a9c6777d00