### PR TITLE
Update dashboard analytics to use new tool fields

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -334,12 +334,25 @@ export async function getToolChangesByInsertType(insertType, insertCategory = nu
       .order('created_at', { ascending: false });
 
     if (insertCategory === 'rougher') {
-      query = query.eq('first_rougher', insertType);
+      query = query.or(
+        `new_first_rougher.eq.${insertType},old_first_rougher.eq.${insertType},first_rougher.eq.${insertType}`
+      );
     } else if (insertCategory === 'finish') {
-      query = query.eq('finish_tool', insertType);
+      query = query.or(
+        `new_finish_tool.eq.${insertType},old_finish_tool.eq.${insertType},finish_tool.eq.${insertType}`
+      );
     } else {
-      // Search both fields
-      query = query.or(`first_rougher.eq.${insertType},finish_tool.eq.${insertType}`);
+      // Search both rougher and finish columns
+      query = query.or(
+        [
+          `new_first_rougher.eq.${insertType}`,
+          `old_first_rougher.eq.${insertType}`,
+          `first_rougher.eq.${insertType}`,
+          `new_finish_tool.eq.${insertType}`,
+          `old_finish_tool.eq.${insertType}`,
+          `finish_tool.eq.${insertType}`
+        ].join(',')
+      );
     }
 
     const { data, error } = await query;
@@ -409,7 +422,11 @@ export async function getInsertUsageAnalytics(dateRange = 30) {
     const { data, error } = await supabase
       .from('tool_changes')
       .select(`
+        new_first_rougher,
+        old_first_rougher,
         first_rougher,
+        new_finish_tool,
+        old_finish_tool,
         finish_tool,
         change_reason,
         pieces_produced,
@@ -441,15 +458,27 @@ export async function getInsertUsageAnalytics(dateRange = 30) {
 
     data.forEach(change => {
       // Track rougher insert usage
-      if (change.first_rougher) {
-        analytics.rougherUsage[change.first_rougher] = 
-          (analytics.rougherUsage[change.first_rougher] || 0) + 1;
+      const rougherInsert =
+        change.new_first_rougher ||
+        change.old_first_rougher ||
+        change.first_rougher ||
+        null;
+
+      if (rougherInsert) {
+        analytics.rougherUsage[rougherInsert] =
+          (analytics.rougherUsage[rougherInsert] || 0) + 1;
       }
 
       // Track finish insert usage
-      if (change.finish_tool) {
-        analytics.finishUsage[change.finish_tool] = 
-          (analytics.finishUsage[change.finish_tool] || 0) + 1;
+      const finishInsert =
+        change.new_finish_tool ||
+        change.old_finish_tool ||
+        change.finish_tool ||
+        null;
+
+      if (finishInsert) {
+        analytics.finishUsage[finishInsert] =
+          (analytics.finishUsage[finishInsert] || 0) + 1;
       }
 
       // Track change reasons
@@ -507,7 +536,11 @@ export async function getToolCostAnalysis(dateRange = 30) {
     const { data: changes, error: changesError } = await supabase
       .from('tool_changes')
       .select(`
+        new_first_rougher,
+        old_first_rougher,
         first_rougher,
+        new_finish_tool,
+        old_finish_tool,
         finish_tool,
         pieces_produced,
         downtime_minutes,
@@ -532,13 +565,25 @@ export async function getToolCostAnalysis(dateRange = 30) {
 
     changes.forEach(change => {
       // Calculate insert costs
-      const rougherCost = costs.find(c => 
-        c.insert_type === change.first_rougher
-      )?.cost_per_tool || 25; // Default $25
+      const rougherInsert =
+        change.new_first_rougher ||
+        change.old_first_rougher ||
+        change.first_rougher ||
+        null;
+      const rougherCostEntry = rougherInsert
+        ? costs.find(c => c.insert_type === rougherInsert)
+        : null;
+      const rougherCost = rougherCostEntry?.cost_per_tool || 25; // Default $25
 
-      const finishCost = costs.find(c => 
-        c.insert_type === change.finish_tool
-      )?.cost_per_tool || 30; // Default $30
+      const finishInsert =
+        change.new_finish_tool ||
+        change.old_finish_tool ||
+        change.finish_tool ||
+        null;
+      const finishCostEntry = finishInsert
+        ? costs.find(c => c.insert_type === finishInsert)
+        : null;
+      const finishCost = finishCostEntry?.cost_per_tool || 30; // Default $30
 
       totalInsertCost += rougherCost + finishCost;
 

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -46,8 +46,20 @@ const mapToolChangeForDisplay = (toolChange) => {
   const equipmentDisplay =
     toolChange.machine_number || toolChange.equipment_number || toolChange.work_center || 'N/A'
 
-  const firstRougherDisplay = toolChange.first_rougher || toolChange.new_tool_id || 'N/A'
-  const finishToolDisplay = toolChange.finish_tool || toolChange.new_tool_id || 'N/A'
+  const firstRougherDisplay =
+    toolChange.new_first_rougher ||
+    toolChange.old_first_rougher ||
+    toolChange.first_rougher ||
+    toolChange.new_tool_id ||
+    toolChange.old_tool_id ||
+    'N/A'
+  const finishToolDisplay =
+    toolChange.new_finish_tool ||
+    toolChange.old_finish_tool ||
+    toolChange.finish_tool ||
+    toolChange.new_tool_id ||
+    toolChange.old_tool_id ||
+    'N/A'
 
   const changeReasonDisplay =
     toolChange.change_reason ||
@@ -208,8 +220,10 @@ const debugToolChangeData = async () => {
         original_operator: latest.operator,
         original_machine: latest.machine_number,
         original_equipment: latest.equipment_number,
-        original_first_rougher: latest.first_rougher,
-        original_finish_tool: latest.finish_tool,
+        original_new_first_rougher: latest.new_first_rougher,
+        original_old_first_rougher: latest.old_first_rougher,
+        original_new_finish_tool: latest.new_finish_tool,
+        original_old_finish_tool: latest.old_finish_tool,
         original_change_reason: latest.change_reason,
         mapped_operator: mapped.operator,
         mapped_equipment: mapped.equipment,


### PR DESCRIPTION
## Summary
- update the dashboard mapping to prioritize the new rougher and finisher insert fields while keeping legacy fallbacks
- align Supabase analytics and cost queries with the new insert columns so usage and cost reporting stay accurate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60c2ee18c832a99a4f0b5d328d74c