### PR TITLE
Respect stored tool change costs in analysis

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -544,6 +544,9 @@ export async function getToolCostAnalysis(dateRange = 30) {
         finish_tool,
         pieces_produced,
         downtime_minutes,
+        rougher_cost,
+        finish_cost,
+        total_tool_cost,
         date,
         equipment_number
       `)
@@ -563,29 +566,49 @@ export async function getToolCostAnalysis(dateRange = 30) {
     let totalDowntimeCost = 0;
     const downtimeHourlyRate = 150; // $150/hour machine rate
 
+    const parseCostValue = value => {
+      if (value === null || value === undefined) return null;
+      const numericValue = typeof value === 'number' ? value : parseFloat(value);
+      return Number.isFinite(numericValue) ? numericValue : null;
+    };
+
     changes.forEach(change => {
-      // Calculate insert costs
-      const rougherInsert =
-        change.new_first_rougher ||
-        change.old_first_rougher ||
-        change.first_rougher ||
-        null;
-      const rougherCostEntry = rougherInsert
-        ? costs.find(c => c.insert_type === rougherInsert)
-        : null;
-      const rougherCost = rougherCostEntry?.cost_per_tool || 25; // Default $25
+      // Calculate insert costs prioritizing stored values
+      const recordedRougherCost = parseCostValue(change.rougher_cost);
+      const recordedFinishCost = parseCostValue(change.finish_cost);
+      const recordedTotalCost = parseCostValue(change.total_tool_cost);
 
-      const finishInsert =
-        change.new_finish_tool ||
-        change.old_finish_tool ||
-        change.finish_tool ||
-        null;
-      const finishCostEntry = finishInsert
-        ? costs.find(c => c.insert_type === finishInsert)
-        : null;
-      const finishCost = finishCostEntry?.cost_per_tool || 30; // Default $30
+      let changeInsertCost = 0;
 
-      totalInsertCost += rougherCost + finishCost;
+      if (recordedRougherCost !== null || recordedFinishCost !== null) {
+        changeInsertCost += (recordedRougherCost || 0) + (recordedFinishCost || 0);
+      } else if (recordedTotalCost !== null) {
+        changeInsertCost += recordedTotalCost;
+      } else {
+        const rougherInsert =
+          change.new_first_rougher ||
+          change.old_first_rougher ||
+          change.first_rougher ||
+          null;
+        const rougherCostEntry = rougherInsert
+          ? costs.find(c => c.insert_type === rougherInsert)
+          : null;
+        const rougherCost = rougherCostEntry?.cost_per_tool || 25; // Default $25
+
+        const finishInsert =
+          change.new_finish_tool ||
+          change.old_finish_tool ||
+          change.finish_tool ||
+          null;
+        const finishCostEntry = finishInsert
+          ? costs.find(c => c.insert_type === finishInsert)
+          : null;
+        const finishCost = finishCostEntry?.cost_per_tool || 30; // Default $30
+
+        changeInsertCost += rougherCost + finishCost;
+      }
+
+      totalInsertCost += changeInsertCost;
 
       // Calculate downtime costs
       if (change.downtime_minutes) {


### PR DESCRIPTION
## Summary
- include stored rougher, finish, and total tool costs when loading tool change records for analysis
- prioritize recorded tool costs over lookup values so totals reflect saved data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60d3bed34832ab848db92dfe7ec36