### PR TITLE
Ensure dashboard analytics use numeric coercion

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -453,6 +453,11 @@ export async function getInsertUsageAnalytics(dateRange = 30) {
       equipmentUsage: {}
     };
 
+    const toNumber = value => {
+      const numericValue = Number(value);
+      return Number.isFinite(numericValue) ? numericValue : 0;
+    };
+
     let totalDowntime = 0;
     let downtimeCount = 0;
 
@@ -497,27 +502,28 @@ export async function getInsertUsageAnalytics(dateRange = 30) {
           };
         }
         analytics.operatorPerformance[change.operator].changes++;
-        analytics.operatorPerformance[change.operator].totalPieces += 
-          change.pieces_produced || 0;
-        analytics.operatorPerformance[change.operator].totalDowntime += 
-          change.downtime_minutes || 0;
+        analytics.operatorPerformance[change.operator].totalPieces +=
+          toNumber(change.pieces_produced);
+        analytics.operatorPerformance[change.operator].totalDowntime +=
+          toNumber(change.downtime_minutes);
       }
 
       // Track equipment usage
       if (change.equipment_number) {
-        analytics.equipmentUsage[change.equipment_number] = 
+        analytics.equipmentUsage[change.equipment_number] =
           (analytics.equipmentUsage[change.equipment_number] || 0) + 1;
       }
 
       // Calculate average downtime
-      if (change.downtime_minutes) {
-        totalDowntime += change.downtime_minutes;
+      const downtimeValue = Number(change.downtime_minutes);
+      if (Number.isFinite(downtimeValue)) {
+        totalDowntime += downtimeValue;
         downtimeCount++;
       }
     });
 
-    analytics.averageDowntime = downtimeCount > 0 ? 
-      (totalDowntime / downtimeCount).toFixed(2) : 0;
+    analytics.averageDowntime = downtimeCount > 0 ?
+      Number((totalDowntime / downtimeCount).toFixed(2)) : 0;
 
     return analytics;
   } catch (error) {


### PR DESCRIPTION
## Summary
- coerce dashboard aggregations to use numeric totals for downtime and production values
- normalize tool change display data to surface numeric downtime and pieces produced
- ensure insert usage analytics accumulates numeric downtime and returns a numeric average

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60dd0e0d4832a80efcf4410bc782e