### PR TITLE
Handle missing tool_costs table in cost analysis

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -561,11 +561,26 @@ export async function getToolCostAnalysis(dateRange = 30) {
     if (changesError) throw changesError;
 
     // Get tool costs
-    const { data: costs, error: costsError } = await supabase
+    let costs = [];
+    const { data: costsData, error: costsError } = await supabase
       .from('tool_costs')
       .select('*');
 
-    if (costsError) throw costsError;
+    if (costsError) {
+      const missingRelation =
+        costsError?.code === '42P01' ||
+        costsError?.message?.toLowerCase().includes('does not exist');
+
+      if (missingRelation) {
+        console.warn(
+          '⚠️ tool_costs table not found. Falling back to default cost values.'
+        );
+      } else {
+        throw costsError;
+      }
+    } else {
+      costs = costsData || [];
+    }
 
     // Calculate cost analysis
     let totalInsertCost = 0;


### PR DESCRIPTION
## Summary
- gracefully handle missing tool_costs relation when generating cost analytics
- fall back to default insert costs if the tool_costs table is unavailable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60f7fb9bc832aa4c1801cd4cce868