### PR TITLE
Add resilient tool cost analysis fallback

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -533,32 +533,87 @@ export async function getInsertUsageAnalytics(dateRange = 30) {
 }
 
 // Cost analysis function - updated for new insert types
-export async function getToolCostAnalysis(dateRange = 30) {
+export async function getToolCostAnalysis(dateRange = 30, options = {}) {
   try {
-    const startDate = new Date();
-    startDate.setDate(startDate.getDate() - dateRange);
-    
-    // Get tool changes with cost data
-    const { data: changes, error: changesError } = await supabase
-      .from('tool_changes')
-      .select(`
-        new_first_rougher,
-        old_first_rougher,
-        first_rougher,
-        new_finish_tool,
-        old_finish_tool,
-        finish_tool,
-        pieces_produced,
-        downtime_minutes,
-        rougher_cost,
-        finish_cost,
-        total_tool_cost,
-        date,
-        equipment_number
-      `)
-      .gte('date', startDate.toISOString().split('T')[0]);
+    const sanitizedRange = Number.isFinite(dateRange) && dateRange > 0 ? dateRange : 30;
 
-    if (changesError) throw changesError;
+    const today = new Date();
+    today.setHours(23, 59, 59, 999);
+    const startDate = new Date(today);
+    startDate.setHours(0, 0, 0, 0);
+    startDate.setDate(startDate.getDate() - sanitizedRange);
+
+    const { preloadedChanges = null } = options ?? {};
+
+    const isWithinRange = changeDate => {
+      if (!(changeDate instanceof Date) || Number.isNaN(changeDate.getTime())) {
+        return true;
+      }
+      return changeDate >= startDate && changeDate <= today;
+    };
+
+    const filterChangesByDate = (changes = []) =>
+      changes.filter(change => {
+        if (!change?.date) return true;
+        const changeDate = new Date(change.date);
+        return isWithinRange(changeDate);
+      });
+
+    let changes = Array.isArray(preloadedChanges)
+      ? filterChangesByDate(preloadedChanges)
+      : null;
+
+    if (!changes) {
+      const { data: changesData, error: changesError } = await supabase
+        .from('tool_changes')
+        .select(`
+          new_first_rougher,
+          old_first_rougher,
+          first_rougher,
+          new_finish_tool,
+          old_finish_tool,
+          finish_tool,
+          pieces_produced,
+          downtime_minutes,
+          rougher_cost,
+          finish_cost,
+          total_tool_cost,
+          date,
+          equipment_number
+        `)
+        .gte('date', startDate.toISOString().split('T')[0]);
+
+      if (changesError) {
+        console.warn(
+          '⚠️ Error applying date filter in getToolCostAnalysis. Falling back to local filtering.',
+          changesError
+        );
+
+        const { data: fallbackChanges, error: fallbackError } = await supabase
+          .from('tool_changes')
+          .select(`
+            new_first_rougher,
+            old_first_rougher,
+            first_rougher,
+            new_finish_tool,
+            old_finish_tool,
+            finish_tool,
+            pieces_produced,
+            downtime_minutes,
+            rougher_cost,
+            finish_cost,
+            total_tool_cost,
+            date,
+            equipment_number
+          `);
+
+        if (fallbackError) throw fallbackError;
+
+        changes = filterChangesByDate(fallbackChanges || []);
+      } else {
+        changes = changesData || [];
+      }
+    }
 
     // Get tool costs
     let costs = [];

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -273,12 +273,15 @@ export default function Dashboard() {
   const loadDashboardData = async () => {
     setIsLoading(true)
     try {
-      const [changes, analyticsData, costData] = await Promise.all([
+      const [changes, analyticsData] = await Promise.all([
         getToolChanges(),
-        getInsertUsageAnalytics(selectedDateRange),
-        getToolCostAnalysis(selectedDateRange)
+        getInsertUsageAnalytics(selectedDateRange)
       ])
-      
+
+      const costData = await getToolCostAnalysis(selectedDateRange, {
+        preloadedChanges: changes
+      })
+
       setToolChanges(changes || [])
       setAnalytics(analyticsData)
       setCostAnalysis(costData)


### PR DESCRIPTION
## Summary
- let the cost analysis helper reuse preloaded tool change data and guard against invalid date ranges
- fall back to local filtering when the Supabase date filter errors and keep cost calculations running
- reuse the dashboard's tool change results when loading the cost analytics to avoid redundant queries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7418cdf90832abfbf29627d7c5ba0