### PR TITLE
Default tool change downtime to 10 minutes

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -10,6 +10,32 @@ if (!supabaseUrl || !supabaseAnonKey) {
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
+const DEFAULT_DOWNTIME_MINUTES = 10
+
+const parseOptionalNumber = (value) => {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  if (typeof value === 'string' && value.trim() === '') {
+    return null
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const getDowntimeMinutesWithDefault = (...values) => {
+  for (const value of values) {
+    const parsed = parseOptionalNumber(value)
+    if (parsed !== null) {
+      return parsed
+    }
+  }
+
+  return DEFAULT_DOWNTIME_MINUTES
+}
+
 // Get all active operators
 export async function getOperators() {
   try {
@@ -112,6 +138,11 @@ export async function addToolChange(toolChangeData) {
         .join(', ') ||
       null
 
+    const downtimeMinutes = getDowntimeMinutesWithDefault(
+      toolChangeData.downtime_minutes,
+      toolChangeData.tool_change_duration_minutes
+    )
+
     // Map to your actual database schema field names
     const mappedData = {
       // Basic info - use exact database column names
@@ -172,7 +203,7 @@ export async function addToolChange(toolChangeData) {
       cycle_time_before: toNumberOrNull(toolChangeData.cycle_time_before),
       cycle_time_after: toNumberOrNull(toolChangeData.cycle_time_after),
       cycle_time: toNumberOrNull(toolChangeData.cycle_time),
-      downtime_minutes: toNumberOrNull(toolChangeData.downtime_minutes),
+      downtime_minutes: downtimeMinutes,
 
       // Quality checks
       dimension_check: toolChangeData.dimension_check || null,
@@ -433,6 +464,7 @@ export async function getInsertUsageAnalytics(dateRange = 30) {
         cycle_time_before,
         cycle_time_after,
         downtime_minutes,
+        tool_change_duration_minutes,
         date,
         operator,
         equipment_number
@@ -504,8 +536,13 @@ export async function getInsertUsageAnalytics(dateRange = 30) {
         analytics.operatorPerformance[change.operator].changes++;
         analytics.operatorPerformance[change.operator].totalPieces +=
           toNumber(change.pieces_produced);
+        const operatorDowntime = getDowntimeMinutesWithDefault(
+          change.downtime_minutes,
+          change.tool_change_duration_minutes
+        )
+
         analytics.operatorPerformance[change.operator].totalDowntime +=
-          toNumber(change.downtime_minutes);
+          operatorDowntime
       }
 
       // Track equipment usage
@@ -515,7 +552,11 @@ export async function getInsertUsageAnalytics(dateRange = 30) {
       }
 
       // Calculate average downtime
-      const downtimeValue = Number(change.downtime_minutes);
+      const downtimeValue = getDowntimeMinutesWithDefault(
+        change.downtime_minutes,
+        change.tool_change_duration_minutes
+      )
+
       if (Number.isFinite(downtimeValue)) {
         totalDowntime += downtimeValue;
         downtimeCount++;
@@ -575,6 +616,7 @@ export async function getToolCostAnalysis(dateRange = 30, options = {}) {
           finish_tool,
           pieces_produced,
           downtime_minutes,
+          tool_change_duration_minutes,
           rougher_cost,
           finish_cost,
           total_tool_cost,
@@ -600,6 +642,7 @@ export async function getToolCostAnalysis(dateRange = 30, options = {}) {
             finish_tool,
             pieces_produced,
             downtime_minutes,
+            tool_change_duration_minutes,
             rougher_cost,
             finish_cost,
             total_tool_cost,
@@ -687,8 +730,13 @@ export async function getToolCostAnalysis(dateRange = 30, options = {}) {
       totalInsertCost += changeInsertCost;
 
       // Calculate downtime costs
-      if (change.downtime_minutes) {
-        totalDowntimeCost += (change.downtime_minutes / 60) * downtimeHourlyRate;
+      const downtimeMinutesForChange = getDowntimeMinutesWithDefault(
+        change.downtime_minutes,
+        change.tool_change_duration_minutes
+      )
+
+      if (Number.isFinite(downtimeMinutesForChange)) {
+        totalDowntimeCost += (downtimeMinutesForChange / 60) * downtimeHourlyRate
       }
     });
 
@@ -720,6 +768,7 @@ export async function getOperatorPerformanceAnalytics(dateRange = 30) {
         operator_id,
         pieces_produced,
         downtime_minutes,
+        tool_change_duration_minutes,
         cycle_time_before,
         cycle_time_after,
         change_reason,
@@ -758,7 +807,15 @@ export async function getOperatorPerformanceAnalytics(dateRange = 30) {
       const stats = operatorStats[operatorKey];
       stats.tool_changes++;
       stats.total_pieces += change.pieces_produced || 0;
-      stats.total_downtime += change.downtime_minutes || 0;
+
+      const downtimeMinutes = getDowntimeMinutesWithDefault(
+        change.downtime_minutes,
+        change.tool_change_duration_minutes
+      )
+
+      if (Number.isFinite(downtimeMinutes)) {
+        stats.total_downtime += downtimeMinutes;
+      }
 
       // Calculate cycle time improvement
       if (change.cycle_time_before && change.cycle_time_after) {


### PR DESCRIPTION
## Summary
- add shared helpers to normalize downtime minutes and default to 10 when data is missing
- ensure all analytics and cost calculations treat each tool change as 10 minutes of downtime unless an explicit value exists
- update the dashboard to display and chart the normalized downtime minutes per change

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d771e78bc0832a9d73fff03a1ec30a