### PR TITLE
Cache unsupported tool change columns

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -235,8 +235,15 @@ export async function addToolChange(toolChangeData) {
   }
 }
 
+const unsupportedToolChangeColumns = new Set()
+
+const filterUnsupportedColumns = (data) =>
+  Object.fromEntries(
+    Object.entries(data).filter(([column]) => !unsupportedToolChangeColumns.has(column))
+  )
+
 async function insertToolChangeWithFallback(initialData) {
-  let payload = { ...initialData }
+  let payload = filterUnsupportedColumns(initialData)
   const removedColumns = new Set()
 
   while (true) {
@@ -261,6 +268,7 @@ async function insertToolChangeWithFallback(initialData) {
 
       if (missingColumn && Object.prototype.hasOwnProperty.call(payload, missingColumn)) {
         console.warn(`⚠️ Column '${missingColumn}' not found in schema. Retrying without it...`)
+        unsupportedToolChangeColumns.add(missingColumn)
         delete payload[missingColumn]
         removedColumns.add(missingColumn)
         continue


### PR DESCRIPTION
## Summary
- cache unsupported tool change columns reported by Supabase so they are skipped in future payloads
- filter insert payloads using the cached list to avoid repeated 400 retries during tool change submissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d830fb6260832aa78a75e904e5b725