### PR TITLE
Derive after blast product family via measurement template join

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -118,7 +118,7 @@ export async function getOperatorById(identifier) {
 
 export async function getAfterBlastMeasurements({ limit = 75 } = {}) {
   try {
-    const query = supabase
+    const { data, error } = await supabase
       .from('dimensional_measurements')
       .select(
         `
@@ -127,7 +127,6 @@ export async function getAfterBlastMeasurements({ limit = 75 } = {}) {
         heat_number,
         tracking_number,
         product_number,
-        product_family,
         measurement_date,
         measurement_time,
         operator,
@@ -148,7 +147,10 @@ export async function getAfterBlastMeasurements({ limit = 75 } = {}) {
         length_to_flange_actual,
         length_to_flange_target,
         length_to_flange_tolerance,
-        notes
+        notes,
+        measurement_templates!dimensional_measurements_product_number_fkey (
+          product_family
+        )
       `
       )
       .order('measurement_date', { ascending: false, nullsLast: false })
@@ -156,14 +158,23 @@ export async function getAfterBlastMeasurements({ limit = 75 } = {}) {
       .order('created_at', { ascending: false })
       .limit(limit)
 
-    const { data, error } = await query
-
     if (error) {
       console.error('❌ Error fetching after blast measurements:', error)
       throw error
     }
 
-    return data || []
+    return (data || []).map((record) => {
+      const {
+        measurement_templates: template,
+        product_family,
+        ...rest
+      } = record
+
+      return {
+        ...rest,
+        product_family: product_family ?? template?.product_family ?? null
+      }
+    })
   } catch (error) {
     console.error('❌ getAfterBlastMeasurements failed:', error)
     return []


### PR DESCRIPTION
## Summary
- fetch after blast measurements with a measurement_templates join instead of selecting the product_family column directly
- flatten the joined product_family onto each measurement so dashboards continue to render the family label

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9d52b7a84832aa4133c3954852bc3