### PR TITLE
Fix after blast measurement template lookup without FK

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -118,7 +118,7 @@ export async function getOperatorById(identifier) {
 
 export async function getAfterBlastMeasurements({ limit = 75 } = {}) {
   try {
-    const { data, error } = await supabase
+    const { data: measurements, error } = await supabase
       .from('dimensional_measurements')
       .select(
         `
@@ -127,6 +127,7 @@ export async function getAfterBlastMeasurements({ limit = 75 } = {}) {
         heat_number,
         tracking_number,
         product_number,
+        product_family,
         measurement_date,
         measurement_time,
         operator,
@@ -147,10 +148,7 @@ export async function getAfterBlastMeasurements({ limit = 75 } = {}) {
         length_to_flange_actual,
         length_to_flange_target,
         length_to_flange_tolerance,
-        notes,
-        measurement_templates!dimensional_measurements_product_number_fkey (
-          product_family
-        )
+        notes
       `
       )
       .order('measurement_date', { ascending: false, nullsLast: false })
@@ -163,16 +161,46 @@ export async function getAfterBlastMeasurements({ limit = 75 } = {}) {
       throw error
     }
 
-    return (data || []).map((record) => {
-      const {
-        measurement_templates: template,
-        product_family,
-        ...rest
-      } = record
+    const productNumbers = Array.from(
+      new Set(
+        (measurements || [])
+          .map((record) => record?.product_number)
+          .filter((value) => typeof value === 'string' && value.trim() !== '')
+      )
+    )
+
+    let templateMap = {}
+
+    if (productNumbers.length > 0) {
+      const { data: templates, error: templateError } = await supabase
+        .from('measurement_templates')
+        .select('product_number, product_family')
+        .in('product_number', productNumbers)
+
+      if (templateError) {
+        console.error(
+          '❌ Error fetching measurement template metadata:',
+          templateError
+        )
+      } else if (templates?.length) {
+        templateMap = templates.reduce((acc, template) => {
+          if (template?.product_number) {
+            acc[template.product_number] = template
+          }
+          return acc
+        }, {})
+      }
+    }
+
+    return (measurements || []).map((record) => {
+      const template = record?.product_number
+        ? templateMap[record.product_number]
+        : null
 
       return {
-        ...rest,
-        product_family: product_family ?? template?.product_family ?? null
+        ...record,
+        product_family:
+          record?.product_family ?? template?.product_family ?? null
       }
     })
   } catch (error) {


### PR DESCRIPTION
## Summary
- avoid selecting a nonexistent foreign key relationship when loading after blast measurements
- backfill product family details by manually looking up measurement templates by product number

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9dad1c350832aaa12d3b2787c451e