### PR TITLE
Route heat treatment UI through open API

### DIFF
--- a/components/HeatTreatmentForm.js
+++ b/components/HeatTreatmentForm.js
@@ -1,0 +1,508 @@
+import { useState } from 'react'
+import { Flame, Save, RotateCcw, AlertCircle, CheckCircle } from 'lucide-react'
+
+const LOAD_TYPES = [
+  { value: 'WQ', label: 'Water Quench (WQ)' },
+  { value: 'AC', label: 'Air Cool (AC)' },
+  { value: 'F.C.A.', label: 'Furnace Cool Anneal (F.C.A.)' },
+  { value: 'TEMPER', label: 'Tempering (TEMPER)' },
+  { value: 'NORM', label: 'Normalize (NORM)' },
+  { value: 'AQ', label: 'Air Quench (AQ)' },
+  { value: 'A.H.', label: 'Anneal Harden (A.H.)' },
+  { value: 'S.R.', label: 'Stress Relief (S.R.)' }
+]
+
+const MATERIAL_TYPES = [
+  'CAT3', 'CAT4', 'CAT4 MOD', 'CF8', 'CF3', 'CF8M', 'CF3M', 'CF10SMNN', 
+  'CA-15', 'CA-40', 'CA-40 ROLL', 'CB7CU-1', 'DUPLEX 4A', 'C-5',
+  '52100-IC', '440-A', '440-C', 'LW4330', '8630-IC', '10B', 'CH-13',
+  'SC15-3MO', 'HC250', 'DUC-IRON', 'LEWMET 115', 'CK20-1', 'CA6MN-1'
+]
+
+export default function HeatTreatmentForm({ initialData = null, onSuccess = () => {} }) {
+  const [formData, setFormData] = useState(initialData || {
+    heat_number: '',
+    furnace_number: '',
+    load_number: '',
+    load_type: '',
+    job_number: '',
+    part_number: '',
+    material_type: '',
+    cast_weight: '',
+    test_material: '',
+    temp1_fahrenheit: '',
+    time1_hours: '',
+    temp2_fahrenheit: '',
+    time2_hours: '',
+    temp3_fahrenheit: '',
+    time3_hours: '',
+    temp4_fahrenheit: '',
+    time4_hours: '',
+    hot_str_tir: '',
+    cold_str_tir: '',
+    hot_end_bhn: '',
+    cold_end_bhn: '',
+    gas_usage: '',
+    notes: '',
+    day_finished: new Date().toISOString().split('T')[0]
+  })
+
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState({ type: '', text: '' })
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setFormData(prev => ({ ...prev, [name]: value }))
+  }
+
+  const handleReset = () => {
+    setFormData({
+      heat_number: '',
+      furnace_number: '',
+      load_number: '',
+      load_type: '',
+      job_number: '',
+      part_number: '',
+      material_type: '',
+      cast_weight: '',
+      test_material: '',
+      temp1_fahrenheit: '',
+      time1_hours: '',
+      temp2_fahrenheit: '',
+      time2_hours: '',
+      temp3_fahrenheit: '',
+      time3_hours: '',
+      temp4_fahrenheit: '',
+      time4_hours: '',
+      hot_str_tir: '',
+      cold_str_tir: '',
+      hot_end_bhn: '',
+      cold_end_bhn: '',
+      gas_usage: '',
+      notes: '',
+      day_finished: new Date().toISOString().split('T')[0]
+    })
+    setMessage({ type: '', text: '' })
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setLoading(true)
+    setMessage({ type: '', text: '' })
+
+    try {
+      // Validate required fields
+      if (!formData.heat_number || !formData.day_finished) {
+        throw new Error('Heat Number and Day Finished are required')
+      }
+
+      // Prepare data - convert empty strings to null for numeric fields
+      const dataToSubmit = {
+        ...formData,
+        furnace_number: formData.furnace_number || null,
+        load_number: formData.load_number || null,
+        job_number: formData.job_number || null,
+        cast_weight: formData.cast_weight || null,
+        temp1_fahrenheit: formData.temp1_fahrenheit || null,
+        time1_hours: formData.time1_hours || null,
+        temp2_fahrenheit: formData.temp2_fahrenheit || null,
+        time2_hours: formData.time2_hours || null,
+        temp3_fahrenheit: formData.temp3_fahrenheit || null,
+        time3_hours: formData.time3_hours || null,
+        temp4_fahrenheit: formData.temp4_fahrenheit || null,
+        time4_hours: formData.time4_hours || null,
+        hot_str_tir: formData.hot_str_tir || null,
+        cold_str_tir: formData.cold_str_tir || null,
+        hot_end_bhn: formData.hot_end_bhn || null,
+        cold_end_bhn: formData.cold_end_bhn || null,
+        gas_usage: formData.gas_usage || null
+      }
+
+      const url = initialData?.id
+        ? `/api/heat-treatment?id=${encodeURIComponent(initialData.id)}`
+        : '/api/heat-treatment'
+
+      const response = await fetch(url, {
+        method: initialData?.id ? 'PUT' : 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(dataToSubmit)
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        const errorMessage = errorData.message || errorData.error || 'Failed to save heat treatment record'
+        throw new Error(errorMessage)
+      }
+
+      const result = await response.json()
+      const savedRecord = result.data || null
+
+      setMessage({
+        type: 'success',
+        text: `Heat treatment ${initialData?.id ? 'updated' : 'recorded'} successfully!`
+      })
+
+      if (!initialData?.id) {
+        handleReset()
+      }
+
+      if (savedRecord) {
+        onSuccess(savedRecord)
+      }
+    } catch (error) {
+      console.error('Error saving heat treatment:', error)
+      setMessage({ 
+        type: 'error', 
+        text: error.message || 'Failed to save heat treatment record' 
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-8">
+      {/* Header Message */}
+      {message.text && (
+        <div className={`flex items-center gap-3 rounded-xl border p-4 ${
+          message.type === 'success' 
+            ? 'border-emerald-200 bg-emerald-50 text-emerald-800' 
+            : 'border-rose-200 bg-rose-50 text-rose-800'
+        }`}>
+          {message.type === 'success' ? (
+            <CheckCircle size={20} />
+          ) : (
+            <AlertCircle size={20} />
+          )}
+          <span className="font-medium">{message.text}</span>
+        </div>
+      )}
+
+      {/* Heat Identification */}
+      <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+        <h3 className="mb-4 flex items-center gap-2 text-lg font-bold text-spuncast-navy">
+          <Flame size={20} />
+          Heat Identification
+        </h3>
+        <div className="grid gap-4 md:grid-cols-3">
+          <div>
+            <label htmlFor="heat_number" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Heat Number <span className="text-spuncast-red">*</span>
+            </label>
+            <input
+              type="text"
+              id="heat_number"
+              name="heat_number"
+              value={formData.heat_number}
+              onChange={handleChange}
+              required
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="e.g., 25H2323"
+            />
+          </div>
+          <div>
+            <label htmlFor="furnace_number" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Furnace Number
+            </label>
+            <input
+              type="number"
+              id="furnace_number"
+              name="furnace_number"
+              value={formData.furnace_number}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="e.g., 2"
+            />
+          </div>
+          <div>
+            <label htmlFor="load_number" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Load Number
+            </label>
+            <input
+              type="number"
+              id="load_number"
+              name="load_number"
+              value={formData.load_number}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="e.g., 3691"
+            />
+          </div>
+          <div>
+            <label htmlFor="load_type" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Load Type
+            </label>
+            <select
+              id="load_type"
+              name="load_type"
+              value={formData.load_type}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+            >
+              <option value="">Select Load Type</option>
+              {LOAD_TYPES.map(type => (
+                <option key={type.value} value={type.value}>{type.label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="day_finished" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Day Finished <span className="text-spuncast-red">*</span>
+            </label>
+            <input
+              type="date"
+              id="day_finished"
+              name="day_finished"
+              value={formData.day_finished}
+              onChange={handleChange}
+              required
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Job & Part Information */}
+      <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+        <h3 className="mb-4 text-lg font-bold text-spuncast-navy">Job & Part Information</h3>
+        <div className="grid gap-4 md:grid-cols-3">
+          <div>
+            <label htmlFor="job_number" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Job Number
+            </label>
+            <input
+              type="number"
+              id="job_number"
+              name="job_number"
+              value={formData.job_number}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="e.g., 159683"
+            />
+          </div>
+          <div>
+            <label htmlFor="part_number" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Part Number
+            </label>
+            <input
+              type="text"
+              id="part_number"
+              name="part_number"
+              value={formData.part_number}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="e.g., CAT536-6768"
+            />
+          </div>
+          <div>
+            <label htmlFor="material_type" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Material Type
+            </label>
+            <select
+              id="material_type"
+              name="material_type"
+              value={formData.material_type}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+            >
+              <option value="">Select Material</option>
+              {MATERIAL_TYPES.map(material => (
+                <option key={material} value={material}>{material}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="cast_weight" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Cast Weight (lbs)
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              id="cast_weight"
+              name="cast_weight"
+              value={formData.cast_weight}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="e.g., 1330"
+            />
+          </div>
+          <div>
+            <label htmlFor="test_material" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Test Material
+            </label>
+            <input
+              type="text"
+              id="test_material"
+              name="test_material"
+              value={formData.test_material}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="e.g., 25"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Temperature Cycles */}
+      <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+        <h3 className="mb-4 text-lg font-bold text-spuncast-navy">Temperature Cycles</h3>
+        <div className="space-y-4">
+          {[1, 2, 3, 4].map(cycle => (
+            <div key={cycle} className="grid gap-4 md:grid-cols-2 border-l-4 border-spuncast-red pl-4">
+              <div>
+                <label htmlFor={`temp${cycle}_fahrenheit`} className="block text-sm font-semibold text-spuncast-slate mb-1">
+                  Stage {cycle} - Temperature (°F)
+                </label>
+                <input
+                  type="number"
+                  id={`temp${cycle}_fahrenheit`}
+                  name={`temp${cycle}_fahrenheit`}
+                  value={formData[`temp${cycle}_fahrenheit`]}
+                  onChange={handleChange}
+                  className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+                  placeholder="e.g., 1850"
+                />
+              </div>
+              <div>
+                <label htmlFor={`time${cycle}_hours`} className="block text-sm font-semibold text-spuncast-slate mb-1">
+                  Stage {cycle} - Time (hours)
+                </label>
+                <input
+                  type="number"
+                  step="0.01"
+                  id={`time${cycle}_hours`}
+                  name={`time${cycle}_hours`}
+                  value={formData[`time${cycle}_hours`]}
+                  onChange={handleChange}
+                  className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+                  placeholder="e.g., 7"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Test Results */}
+      <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+        <h3 className="mb-4 text-lg font-bold text-spuncast-navy">Test Results</h3>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="hot_str_tir" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Hot Str TIR
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              id="hot_str_tir"
+              name="hot_str_tir"
+              value={formData.hot_str_tir}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+            />
+          </div>
+          <div>
+            <label htmlFor="cold_str_tir" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Cold Str TIR
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              id="cold_str_tir"
+              name="cold_str_tir"
+              value={formData.cold_str_tir}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+            />
+          </div>
+          <div>
+            <label htmlFor="hot_end_bhn" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Hot End BHN
+            </label>
+            <input
+              type="number"
+              id="hot_end_bhn"
+              name="hot_end_bhn"
+              value={formData.hot_end_bhn}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="e.g., 415"
+            />
+          </div>
+          <div>
+            <label htmlFor="cold_end_bhn" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Cold End BHN
+            </label>
+            <input
+              type="number"
+              id="cold_end_bhn"
+              name="cold_end_bhn"
+              value={formData.cold_end_bhn}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="e.g., 302"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Additional Information */}
+      <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+        <h3 className="mb-4 text-lg font-bold text-spuncast-navy">Additional Information</h3>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="gas_usage" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Gas Usage
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              id="gas_usage"
+              name="gas_usage"
+              value={formData.gas_usage}
+              onChange={handleChange}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+            />
+          </div>
+          <div className="md:col-span-2">
+            <label htmlFor="notes" className="block text-sm font-semibold text-spuncast-slate mb-1">
+              Notes
+            </label>
+            <textarea
+              id="notes"
+              name="notes"
+              value={formData.notes}
+              onChange={handleChange}
+              rows="3"
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-spuncast-navy focus:outline-none focus:ring-2 focus:ring-spuncast-navy/20"
+              placeholder="Additional notes or observations..."
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Form Actions */}
+      <div className="flex gap-4 justify-end">
+        <button
+          type="button"
+          onClick={handleReset}
+          disabled={loading}
+          className="inline-flex items-center gap-2 rounded-full border-2 border-spuncast-navy px-6 py-2.5 text-sm font-semibold text-spuncast-navy transition hover:bg-spuncast-navy hover:text-white disabled:opacity-50"
+        >
+          <RotateCcw size={18} />
+          Reset
+        </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className="inline-flex items-center gap-2 rounded-full bg-spuncast-red px-6 py-2.5 text-sm font-semibold text-white shadow-brand transition hover:bg-spuncast-redDark disabled:opacity-50"
+        >
+          <Save size={18} />
+          {loading ? 'Saving...' : initialData?.id ? 'Update' : 'Save'} Heat Treatment
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/lib/heatTreatmentUtils.js
+++ b/lib/heatTreatmentUtils.js
@@ -1,0 +1,309 @@
+/**
+ * Heat Treatment Utility Functions
+ * Helper functions for data processing, calculations, and formatting
+ */
+
+/**
+ * Calculate total cycle time from all temperature stages
+ */
+export function calculateTotalCycleTime(treatment) {
+  const time1 = parseFloat(treatment.time1_hours) || 0
+  const time2 = parseFloat(treatment.time2_hours) || 0
+  const time3 = parseFloat(treatment.time3_hours) || 0
+  const time4 = parseFloat(treatment.time4_hours) || 0
+  return time1 + time2 + time3 + time4
+}
+
+/**
+ * Calculate average BHN from hot and cold end measurements
+ */
+export function calculateAvgBHN(treatment) {
+  const hot = parseFloat(treatment.hot_end_bhn) || 0
+  const cold = parseFloat(treatment.cold_end_bhn) || 0
+  if (hot === 0 && cold === 0) return 0
+  if (hot === 0) return cold
+  if (cold === 0) return hot
+  return Math.round((hot + cold) / 2)
+}
+
+/**
+ * Format load type for display
+ */
+export function formatLoadType(loadType) {
+  const types = {
+    'WQ': 'Water Quench',
+    'AC': 'Air Cool',
+    'F.C.A.': 'Furnace Cool Anneal',
+    'TEMPER': 'Tempering',
+    'NORM': 'Normalize',
+    'AQ': 'Air Quench',
+    'A.H.': 'Anneal Harden',
+    'S.R.': 'Stress Relief'
+  }
+  return types[loadType] || loadType
+}
+
+/**
+ * Get load type color for badges
+ */
+export function getLoadTypeColor(loadType) {
+  const colors = {
+    'WQ': 'bg-blue-100 text-blue-800',
+    'AC': 'bg-green-100 text-green-800',
+    'F.C.A.': 'bg-purple-100 text-purple-800',
+    'TEMPER': 'bg-orange-100 text-orange-800',
+    'NORM': 'bg-yellow-100 text-yellow-800',
+    'AQ': 'bg-cyan-100 text-cyan-800',
+    'A.H.': 'bg-pink-100 text-pink-800',
+    'S.R.': 'bg-indigo-100 text-indigo-800'
+  }
+  return colors[loadType] || 'bg-gray-100 text-gray-800'
+}
+
+/**
+ * Validate treatment data before submission
+ */
+export function validateTreatmentData(data) {
+  const errors = []
+
+  // Required fields
+  if (!data.heat_number || data.heat_number.trim() === '') {
+    errors.push('Heat number is required')
+  }
+
+  if (!data.day_finished) {
+    errors.push('Day finished is required')
+  }
+
+  // Numeric validations
+  if (data.cast_weight && isNaN(data.cast_weight)) {
+    errors.push('Cast weight must be a number')
+  }
+
+  if (data.hot_end_bhn && (isNaN(data.hot_end_bhn) || data.hot_end_bhn < 0)) {
+    errors.push('Hot end BHN must be a positive number')
+  }
+
+  if (data.cold_end_bhn && (isNaN(data.cold_end_bhn) || data.cold_end_bhn < 0)) {
+    errors.push('Cold end BHN must be a positive number')
+  }
+
+  // Temperature/time validations
+  for (let i = 1; i <= 4; i++) {
+    const temp = data[`temp${i}_fahrenheit`]
+    const time = data[`time${i}_hours`]
+
+    if (temp && isNaN(temp)) {
+      errors.push(`Temperature ${i} must be a number`)
+    }
+
+    if (time && isNaN(time)) {
+      errors.push(`Time ${i} must be a number`)
+    }
+
+    // If temperature is set, time should be set too
+    if (temp && !time) {
+      errors.push(`Time ${i} is required when temperature ${i} is set`)
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors
+  }
+}
+
+/**
+ * Format date for display
+ */
+export function formatDate(dateString) {
+  if (!dateString) return 'N/A'
+  const date = new Date(dateString)
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  })
+}
+
+/**
+ * Format temperature with unit
+ */
+export function formatTemperature(temp) {
+  if (!temp || isNaN(temp)) return 'N/A'
+  return `${temp}°F`
+}
+
+/**
+ * Format time with unit
+ */
+export function formatTime(hours) {
+  if (!hours || isNaN(hours)) return 'N/A'
+  const h = parseFloat(hours)
+  if (h >= 1) return `${h} hrs`
+  return `${Math.round(h * 60)} min`
+}
+
+/**
+ * Calculate efficiency score based on cycle time and gas usage
+ */
+export function calculateEfficiencyScore(treatment) {
+  const totalTime = calculateTotalCycleTime(treatment)
+  const weight = parseFloat(treatment.cast_weight) || 0
+  const gas = parseFloat(treatment.gas_usage) || 0
+
+  if (totalTime === 0 || weight === 0) return 0
+
+  // Lower is better: less time and gas per pound
+  const timePerPound = totalTime / weight
+  const gasPerPound = gas / weight
+
+  // Simple efficiency score (0-100, higher is better)
+  // This is a simplified formula - adjust based on your standards
+  const score = Math.max(0, 100 - (timePerPound * 10 + gasPerPound * 5))
+  return Math.round(score)
+}
+
+/**
+ * Check if BHN is within acceptable range
+ */
+export function isBHNInRange(bhn, material) {
+  if (!bhn) return null
+
+  // Define acceptable ranges per material (customize as needed)
+  const ranges = {
+    'CAT3': { min: 269, max: 444 },
+    'CAT4': { min: 241, max: 415 },
+    'CA-40': { min: 388, max: 477 },
+    'CF8': { min: 140, max: 220 },
+    '52100-IC': { min: 207, max: 248 }
+    // Add more materials as needed
+  }
+
+  const range = ranges[material]
+  if (!range) return null
+
+  return bhn >= range.min && bhn <= range.max
+}
+
+/**
+ * Get temperature stage summary
+ */
+export function getTemperatureStageSummary(treatment) {
+  const stages = []
+  for (let i = 1; i <= 4; i++) {
+    const temp = treatment[`temp${i}_fahrenheit`]
+    const time = treatment[`time${i}_hours`]
+    if (temp && time) {
+      stages.push({
+        stage: i,
+        temperature: temp,
+        time: time,
+        formatted: `${temp}°F for ${time} hrs`
+      })
+    }
+  }
+  return stages
+}
+
+/**
+ * Export treatment data to CSV format
+ */
+export function exportToCSV(treatments) {
+  const headers = [
+    'Heat Number', 'Furnace', 'Load Number', 'Load Type', 'Day Finished',
+    'Job Number', 'Part Number', 'Material', 'Cast Weight',
+    'Temp1', 'Time1', 'Temp2', 'Time2', 'Temp3', 'Time3', 'Temp4', 'Time4',
+    'Hot End BHN', 'Cold End BHN', 'Gas Usage', 'Notes'
+  ]
+
+  const rows = treatments.map(t => [
+    t.heat_number,
+    t.furnace_number || '',
+    t.load_number || '',
+    t.load_type || '',
+    t.day_finished,
+    t.job_number || '',
+    t.part_number || '',
+    t.material_type || '',
+    t.cast_weight || '',
+    t.temp1_fahrenheit || '',
+    t.time1_hours || '',
+    t.temp2_fahrenheit || '',
+    t.time2_hours || '',
+    t.temp3_fahrenheit || '',
+    t.time3_hours || '',
+    t.temp4_fahrenheit || '',
+    t.time4_hours || '',
+    t.hot_end_bhn || '',
+    t.cold_end_bhn || '',
+    t.gas_usage || '',
+    (t.notes || '').replace(/"/g, '""') // Escape quotes
+  ])
+
+  const csvContent = [
+    headers.join(','),
+    ...rows.map(row => row.map(cell => `"${cell}"`).join(','))
+  ].join('\n')
+
+  return csvContent
+}
+
+/**
+ * Download CSV file
+ */
+export function downloadCSV(csvContent, filename = 'heat-treatments.csv') {
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+  const link = document.createElement('a')
+  const url = URL.createObjectURL(blob)
+  
+  link.setAttribute('href', url)
+  link.setAttribute('download', filename)
+  link.style.visibility = 'hidden'
+  
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * Filter treatments by date range
+ */
+export function filterByDateRange(treatments, startDate, endDate) {
+  return treatments.filter(t => {
+    const date = new Date(t.day_finished)
+    const start = new Date(startDate)
+    const end = new Date(endDate)
+    return date >= start && date <= end
+  })
+}
+
+/**
+ * Group treatments by furnace
+ */
+export function groupByFurnace(treatments) {
+  return treatments.reduce((acc, treatment) => {
+    const furnace = treatment.furnace_number || 'Unassigned'
+    if (!acc[furnace]) {
+      acc[furnace] = []
+    }
+    acc[furnace].push(treatment)
+    return acc
+  }, {})
+}
+
+/**
+ * Group treatments by material
+ */
+export function groupByMaterial(treatments) {
+  return treatments.reduce((acc, treatment) => {
+    const material = treatment.material_type || 'Unknown'
+    if (!acc[material]) {
+      acc[material] = []
+    }
+    acc[material].push(treatment)
+    return acc
+  }, {})
+}

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -4,11 +4,23 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  console.warn('Supabase credentials are missing. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.')
+const createMissingCredentialsClient = () => {
+  const message = 'Supabase credentials are missing. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+  console.warn(message)
+
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new Error(message)
+      }
+    }
+  )
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = supabaseUrl && supabaseAnonKey
+  ? createClient(supabaseUrl, supabaseAnonKey)
+  : createMissingCredentialsClient()
 
 const DEFAULT_DOWNTIME_MINUTES = 10
 

--- a/pages/api/heat-treatment/index.js
+++ b/pages/api/heat-treatment/index.js
@@ -1,0 +1,131 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+)
+
+export default async function handler(req, res) {
+  const { method } = req
+
+  try {
+    switch (method) {
+      case 'GET':
+        return await handleGet(req, res)
+      case 'POST':
+        return await handlePost(req, res)
+      case 'PUT':
+        return await handlePut(req, res)
+      case 'DELETE':
+        return await handleDelete(req, res)
+      default:
+        return res.status(405).json({ message: 'Method not allowed' })
+    }
+  } catch (error) {
+    console.error('API Error:', error)
+    return res.status(500).json({ message: 'Internal server error', error: error.message })
+  }
+}
+
+async function handleGet(req, res) {
+  const { id, heat_number, limit = 100, offset = 0 } = req.query
+
+  let query = supabase
+    .from('heat_treatment_log')
+    .select('*')
+    .order('day_finished', { ascending: false })
+    .order('created_at', { ascending: false })
+
+  if (id) {
+    query = query.eq('id', id).single()
+  }
+
+  if (heat_number) {
+    query = query.eq('heat_number', heat_number)
+  }
+
+  if (!id) {
+    query = query.range(offset, offset + limit - 1)
+  }
+
+  const { data, error, count } = await query
+
+  if (error) {
+    return res.status(400).json({ message: 'Failed to fetch heat treatments', error: error.message })
+  }
+
+  return res.status(200).json({ 
+    data, 
+    count,
+    pagination: {
+      limit: parseInt(limit),
+      offset: parseInt(offset)
+    }
+  })
+}
+
+async function handlePost(req, res) {
+  const treatmentData = req.body
+
+  // Validate required fields
+  if (!treatmentData.heat_number || !treatmentData.day_finished) {
+    return res.status(400).json({ 
+      message: 'Missing required fields: heat_number and day_finished are required' 
+    })
+  }
+
+  const { data, error } = await supabase
+    .from('heat_treatment_log')
+    .insert([treatmentData])
+    .select()
+
+  if (error) {
+    return res.status(400).json({ message: 'Failed to create heat treatment', error: error.message })
+  }
+
+  return res.status(201).json({ data: data[0], message: 'Heat treatment created successfully' })
+}
+
+async function handlePut(req, res) {
+  const { id } = req.query
+  const treatmentData = req.body
+
+  if (!id) {
+    return res.status(400).json({ message: 'ID is required for updates' })
+  }
+
+  const { data, error } = await supabase
+    .from('heat_treatment_log')
+    .update(treatmentData)
+    .eq('id', id)
+    .select()
+
+  if (error) {
+    return res.status(400).json({ message: 'Failed to update heat treatment', error: error.message })
+  }
+
+  if (!data || data.length === 0) {
+    return res.status(404).json({ message: 'Heat treatment not found' })
+  }
+
+  return res.status(200).json({ data: data[0], message: 'Heat treatment updated successfully' })
+}
+
+async function handleDelete(req, res) {
+  const { id } = req.query
+
+  if (!id) {
+    return res.status(400).json({ message: 'ID is required for deletion' })
+  }
+
+  const { error } = await supabase
+    .from('heat_treatment_log')
+    .delete()
+    .eq('id', id)
+
+  if (error) {
+    return res.status(400).json({ message: 'Failed to delete heat treatment', error: error.message })
+  }
+
+  return res.status(200).json({ message: 'Heat treatment deleted successfully' })
+}

--- a/pages/api/heat-treatment/stats.js
+++ b/pages/api/heat-treatment/stats.js
@@ -1,0 +1,110 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+)
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  try {
+    const { start_date, end_date, days = 30 } = req.query
+
+    // Calculate date range
+    const endDate = end_date || new Date().toISOString().split('T')[0]
+    const startDate = start_date || new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+
+    // Get overall statistics using the database function
+    const { data: statsData, error: statsError } = await supabase
+      .rpc('get_heat_treatment_stats', {
+        start_date: startDate,
+        end_date: endDate
+      })
+
+    if (statsError) throw statsError
+
+    // Get load type distribution
+    const { data: loadTypeData, error: loadError } = await supabase
+      .from('vw_heat_treatment_by_load_type')
+      .select('*')
+
+    if (loadError) throw loadError
+
+    // Get furnace utilization
+    const { data: furnaceData, error: furnError } = await supabase
+      .rpc('get_furnace_utilization', {
+        start_date: startDate,
+        end_date: endDate
+      })
+
+    if (furnError) throw furnError
+
+    // Get material performance
+    const { data: materialData, error: matError } = await supabase
+      .from('vw_heat_treatment_by_material')
+      .select('*')
+      .limit(10)
+
+    if (matError) throw matError
+
+    // Get daily production
+    const { data: dailyData, error: dailyError } = await supabase
+      .from('vw_daily_heat_treatment_production')
+      .select('*')
+      .gte('day_finished', startDate)
+      .lte('day_finished', endDate)
+      .order('day_finished', { ascending: false })
+      .limit(30)
+
+    if (dailyError) throw dailyError
+
+    // Get recent treatments
+    const { data: recentData, error: recentError } = await supabase
+      .from('vw_recent_heat_treatments')
+      .select('*')
+      .limit(10)
+
+    if (recentError) throw recentError
+
+    // Get today's count
+    const today = new Date().toISOString().split('T')[0]
+    const { data: todayData, error: todayError } = await supabase
+      .from('heat_treatment_log')
+      .select('id', { count: 'exact', head: true })
+      .eq('day_finished', today)
+
+    if (todayError) throw todayError
+
+    const stats = statsData && statsData.length > 0 ? statsData[0] : {
+      total_treatments: 0,
+      total_weight: 0,
+      total_gas: 0,
+      avg_bhn: 0,
+      unique_parts: 0
+    }
+
+    return res.status(200).json({
+      stats: {
+        ...stats,
+        today_treatments: todayData?.count || 0,
+        active_furnaces: furnaceData?.length || 0
+      },
+      load_types: loadTypeData || [],
+      furnaces: furnaceData || [],
+      materials: materialData || [],
+      daily_production: dailyData || [],
+      recent_treatments: recentData || [],
+      date_range: {
+        start: startDate,
+        end: endDate
+      }
+    })
+
+  } catch (error) {
+    console.error('Stats API Error:', error)
+    return res.status(500).json({ message: 'Failed to fetch statistics', error: error.message })
+  }
+}

--- a/pages/heat-treatment/dashboard.js
+++ b/pages/heat-treatment/dashboard.js
@@ -1,0 +1,294 @@
+import { useState, useEffect } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
+import { Flame, TrendingUp, Factory, Gauge, ArrowLeft, RefreshCw } from 'lucide-react'
+
+export default function HeatTreatmentDashboard() {
+  const [stats, setStats] = useState({
+    totalTreatments: 0,
+    todayTreatments: 0,
+    activeFurnaces: 0,
+    avgBHN: 0,
+    totalWeight: 0,
+    totalGas: 0
+  })
+  const [loadTypeData, setLoadTypeData] = useState([])
+  const [furnaceData, setFurnaceData] = useState([])
+  const [materialData, setMaterialData] = useState([])
+  const [recentTreatments, setRecentTreatments] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [dateRange, setDateRange] = useState(30)
+
+  const loadDashboardData = async () => {
+    setLoading(true)
+    try {
+      const startDate = new Date()
+      startDate.setDate(startDate.getDate() - dateRange)
+      const endDate = new Date()
+
+      const start = startDate.toISOString().split('T')[0]
+      const end = endDate.toISOString().split('T')[0]
+
+      const statsResponse = await fetch(`/api/heat-treatment/stats?start_date=${start}&end_date=${end}`)
+
+      if (!statsResponse.ok) {
+        throw new Error('Failed to load dashboard statistics')
+      }
+
+      const statsPayload = await statsResponse.json()
+
+      const stat = statsPayload?.stats || {}
+
+      setStats({
+        totalTreatments: stat.total_treatments || 0,
+        todayTreatments: stat.today_treatments || 0,
+        activeFurnaces: stat.active_furnaces || 0,
+        avgBHN: stat.avg_bhn || 0,
+        totalWeight: stat.total_weight || 0,
+        totalGas: stat.total_gas || 0
+      })
+
+      const loadTypes = statsPayload?.load_types || []
+      setLoadTypeData(loadTypes.map(item => ({
+        name: item.load_type,
+        treatments: item.total_treatments,
+        avgWeight: parseFloat(item.avg_cast_weight || 0),
+        avgGas: parseFloat(item.avg_gas_usage || 0)
+      })))
+
+      const furnaces = statsPayload?.furnaces || []
+      setFurnaceData(furnaces.map(item => ({
+        furnace: `Furnace ${item.furnace_number}`,
+        treatments: item.total_treatments,
+        avgTime: parseFloat(item.avg_total_time || 0),
+        gas: parseFloat(item.total_gas_usage || 0)
+      })))
+
+      const materials = statsPayload?.materials || []
+      setMaterialData(materials.map(item => ({
+        name: item.material_type,
+        treatments: item.total_treatments,
+        avgBHN: parseFloat(item.avg_hot_bhn || 0)
+      })))
+
+      const recent = statsPayload?.recent_treatments || []
+      setRecentTreatments(recent)
+
+    } catch (error) {
+      console.error('Error loading dashboard data:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadDashboardData()
+  }, [dateRange])
+
+  return (
+    <>
+      <Head>
+        <title>Heat Treatment Dashboard | Manufacturing System</title>
+      </Head>
+
+      <div className="min-h-screen bg-gradient-to-br from-spuncast-sky via-white to-spuncast-sky/50">
+        {/* Header */}
+        <header className="bg-white/95 backdrop-blur border-b border-spuncast-navy/10 shadow-sm">
+          <div className="max-w-7xl mx-auto px-4 py-5">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div className="flex items-center gap-4">
+                <Link href="/" className="text-spuncast-navy hover:text-spuncast-navyDark transition">
+                  <ArrowLeft size={24} />
+                </Link>
+                <div className="flex items-center gap-4">
+                  <Flame className="h-10 w-10 text-spuncast-red" />
+                  <div>
+                    <p className="text-sm uppercase tracking-[0.3em] text-spuncast-red font-semibold">Analytics</p>
+                    <h1 className="text-2xl font-bold text-spuncast-navy">Heat Treatment Dashboard</h1>
+                  </div>
+                </div>
+              </div>
+              <div className="flex gap-3">
+                <select
+                  value={dateRange}
+                  onChange={(e) => setDateRange(Number(e.target.value))}
+                  className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold focus:border-spuncast-navy focus:outline-none"
+                >
+                  <option value={7}>Last 7 days</option>
+                  <option value={30}>Last 30 days</option>
+                  <option value={90}>Last 90 days</option>
+                  <option value={180}>Last 6 months</option>
+                </select>
+                <button
+                  onClick={loadDashboardData}
+                  disabled={loading}
+                  className="inline-flex items-center gap-2 rounded-full bg-spuncast-red px-5 py-2 text-sm font-semibold text-white shadow-brand transition hover:bg-spuncast-redDark disabled:opacity-50"
+                >
+                  <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+                  Refresh
+                </button>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <main className="mx-auto max-w-7xl space-y-8 px-4 py-8">
+          {/* Quick Stats */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-spuncast-slate">Total Treatments</p>
+                  <p className="text-3xl font-bold text-spuncast-navy">{stats.totalTreatments}</p>
+                </div>
+                <TrendingUp className="h-10 w-10 text-spuncast-navy" />
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-spuncast-slate">Today's Treatments</p>
+                  <p className="text-3xl font-bold text-spuncast-red">{stats.todayTreatments}</p>
+                </div>
+                <Flame className="h-10 w-10 text-spuncast-red" />
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-spuncast-slate">Active Furnaces</p>
+                  <p className="text-3xl font-bold text-spuncast-navy">{stats.activeFurnaces}</p>
+                </div>
+                <Factory className="h-10 w-10 text-spuncast-navy" />
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-spuncast-slate">Avg BHN</p>
+                  <p className="text-3xl font-bold text-spuncast-red">{Math.round(stats.avgBHN)}</p>
+                </div>
+                <Gauge className="h-10 w-10 text-spuncast-red" />
+              </div>
+            </div>
+          </div>
+
+          {/* Charts Row 1 */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* Load Type Distribution */}
+            <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+              <h3 className="text-lg font-bold text-spuncast-navy mb-4">Treatments by Load Type</h3>
+              <ResponsiveContainer width="100%" height={300}>
+                <BarChart data={loadTypeData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Bar dataKey="treatments" fill="#003865" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* Furnace Utilization */}
+            <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+              <h3 className="text-lg font-bold text-spuncast-navy mb-4">Furnace Utilization</h3>
+              <ResponsiveContainer width="100%" height={300}>
+                <BarChart data={furnaceData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="furnace" />
+                  <YAxis />
+                  <Tooltip />
+                  <Bar dataKey="treatments" fill="#E41E2B" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          {/* Material Performance */}
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+            <h3 className="text-lg font-bold text-spuncast-navy mb-4">Material Performance (Top 10)</h3>
+            <ResponsiveContainer width="100%" height={400}>
+              <BarChart data={materialData} layout="vertical">
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis type="number" />
+                <YAxis dataKey="name" type="category" width={120} />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="treatments" fill="#003865" name="Treatments" />
+                <Bar dataKey="avgBHN" fill="#E41E2B" name="Avg BHN" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+
+          {/* Recent Treatments Table */}
+          <div className="rounded-2xl border border-white/60 bg-white p-6 shadow-brand">
+            <h3 className="text-lg font-bold text-spuncast-navy mb-4">Recent Treatments</h3>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b-2 border-spuncast-navy/10">
+                    <th className="text-left p-3 text-sm font-semibold text-spuncast-slate">Heat Number</th>
+                    <th className="text-left p-3 text-sm font-semibold text-spuncast-slate">Furnace</th>
+                    <th className="text-left p-3 text-sm font-semibold text-spuncast-slate">Load Type</th>
+                    <th className="text-left p-3 text-sm font-semibold text-spuncast-slate">Part Number</th>
+                    <th className="text-left p-3 text-sm font-semibold text-spuncast-slate">Material</th>
+                    <th className="text-left p-3 text-sm font-semibold text-spuncast-slate">BHN</th>
+                    <th className="text-left p-3 text-sm font-semibold text-spuncast-slate">Date</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {recentTreatments.map(treatment => (
+                    <tr key={treatment.id} className="border-b border-gray-100 hover:bg-spuncast-sky/30">
+                      <td className="p-3 text-sm font-medium text-spuncast-navy">{treatment.heat_number}</td>
+                      <td className="p-3 text-sm">{treatment.furnace_number || '-'}</td>
+                      <td className="p-3 text-sm">
+                        <span className="inline-block rounded-full bg-spuncast-navy/10 px-3 py-1 text-xs font-semibold text-spuncast-navy">
+                          {treatment.load_type || 'N/A'}
+                        </span>
+                      </td>
+                      <td className="p-3 text-sm">{treatment.part_number || '-'}</td>
+                      <td className="p-3 text-sm">{treatment.material_type || '-'}</td>
+                      <td className="p-3 text-sm font-semibold text-spuncast-red">{treatment.hot_end_bhn || '-'}</td>
+                      <td className="p-3 text-sm text-gray-600">
+                        {new Date(treatment.day_finished).toLocaleDateString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {recentTreatments.length === 0 && !loading && (
+                <div className="text-center py-8 text-gray-500">
+                  No treatments found for the selected period
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Summary Stats */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="rounded-2xl border border-white/60 bg-gradient-to-br from-spuncast-navy to-spuncast-navyDark p-6 shadow-brand text-white">
+              <p className="text-sm font-semibold opacity-90 mb-1">Total Weight Processed</p>
+              <p className="text-3xl font-bold">{stats.totalWeight.toLocaleString()} lbs</p>
+            </div>
+            <div className="rounded-2xl border border-white/60 bg-gradient-to-br from-spuncast-red to-spuncast-redDark p-6 shadow-brand text-white">
+              <p className="text-sm font-semibold opacity-90 mb-1">Total Gas Usage</p>
+              <p className="text-3xl font-bold">{stats.totalGas.toLocaleString()}</p>
+            </div>
+            <div className="rounded-2xl border border-white/60 bg-gradient-to-br from-spuncast-slate to-spuncast-navy p-6 shadow-brand text-white">
+              <p className="text-sm font-semibold opacity-90 mb-1">Avg Weight per Treatment</p>
+              <p className="text-3xl font-bold">
+                {stats.totalTreatments > 0 
+                  ? Math.round(stats.totalWeight / stats.totalTreatments).toLocaleString() 
+                  : 0} lbs
+              </p>
+            </div>
+          </div>
+        </main>
+      </div>
+    </>
+  )
+}

--- a/pages/heat-treatment/index.js
+++ b/pages/heat-treatment/index.js
@@ -1,0 +1,180 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import { Flame, Plus, BarChart3, List, ArrowLeft } from 'lucide-react'
+
+export default function HeatTreatmentIndex() {
+  return (
+    <>
+      <Head>
+        <title>Heat Treatment Management | Manufacturing System</title>
+      </Head>
+
+      <div className="min-h-screen bg-gradient-to-br from-spuncast-sky via-white to-spuncast-sky/50">
+        {/* Header */}
+        <header className="bg-white/95 backdrop-blur border-b border-spuncast-navy/10 shadow-sm">
+          <div className="max-w-7xl mx-auto px-4 py-5">
+            <div className="flex items-center gap-4">
+              <Link href="/" className="text-spuncast-navy hover:text-spuncast-navyDark transition">
+                <ArrowLeft size={24} />
+              </Link>
+              <div className="flex items-center gap-4">
+                <img
+                  src="/spuncast-logo.svg"
+                  alt="Spuncast logo"
+                  className="h-14 w-auto drop-shadow-sm"
+                />
+                <div>
+                  <p className="text-sm uppercase tracking-[0.3em] text-spuncast-red font-semibold">Quality Control</p>
+                  <h1 className="text-3xl font-bold text-spuncast-navy">Heat Treatment Management</h1>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <main className="mx-auto max-w-7xl px-4 py-12">
+          {/* Hero Section */}
+          <div className="text-center mb-12">
+            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-spuncast-red/10 mb-4">
+              <Flame className="w-10 h-10 text-spuncast-red" />
+            </div>
+            <h2 className="text-2xl font-bold text-spuncast-navy mb-2">Heat Treatment Operations</h2>
+            <p className="text-spuncast-slate max-w-2xl mx-auto">
+              Track and analyze heat treatment cycles, furnace utilization, and quality metrics across all operations
+            </p>
+          </div>
+
+          {/* Action Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {/* New Entry */}
+            <Link href="/heat-treatment/new">
+              <div className="group rounded-2xl border-2 border-white/60 bg-white p-8 shadow-brand transition hover:shadow-xl hover:border-spuncast-red cursor-pointer">
+                <div className="flex items-center justify-center w-16 h-16 rounded-full bg-spuncast-red/10 mb-4 group-hover:bg-spuncast-red/20 transition">
+                  <Plus className="w-8 h-8 text-spuncast-red" />
+                </div>
+                <h3 className="text-xl font-bold text-spuncast-navy mb-2">New Entry</h3>
+                <p className="text-spuncast-slate mb-4">
+                  Record a new heat treatment cycle with temperature stages, test results, and quality metrics
+                </p>
+                <div className="flex items-center gap-2 text-sm font-semibold text-spuncast-red">
+                  <span>Create Record</span>
+                  <Plus size={16} />
+                </div>
+              </div>
+            </Link>
+
+            {/* Dashboard */}
+            <Link href="/heat-treatment/dashboard">
+              <div className="group rounded-2xl border-2 border-white/60 bg-white p-8 shadow-brand transition hover:shadow-xl hover:border-spuncast-navy cursor-pointer">
+                <div className="flex items-center justify-center w-16 h-16 rounded-full bg-spuncast-navy/10 mb-4 group-hover:bg-spuncast-navy/20 transition">
+                  <BarChart3 className="w-8 h-8 text-spuncast-navy" />
+                </div>
+                <h3 className="text-xl font-bold text-spuncast-navy mb-2">Dashboard</h3>
+                <p className="text-spuncast-slate mb-4">
+                  View analytics, furnace utilization, material performance, and treatment trends
+                </p>
+                <div className="flex items-center gap-2 text-sm font-semibold text-spuncast-navy">
+                  <span>View Analytics</span>
+                  <BarChart3 size={16} />
+                </div>
+              </div>
+            </Link>
+
+            {/* View All */}
+            <Link href="/heat-treatment/list">
+              <div className="group rounded-2xl border-2 border-white/60 bg-white p-8 shadow-brand transition hover:shadow-xl hover:border-spuncast-slate cursor-pointer">
+                <div className="flex items-center justify-center w-16 h-16 rounded-full bg-spuncast-slate/10 mb-4 group-hover:bg-spuncast-slate/20 transition">
+                  <List className="w-8 h-8 text-spuncast-slate" />
+                </div>
+                <h3 className="text-xl font-bold text-spuncast-navy mb-2">View All Records</h3>
+                <p className="text-spuncast-slate mb-4">
+                  Browse, search, and filter all heat treatment records with detailed information
+                </p>
+                <div className="flex items-center gap-2 text-sm font-semibold text-spuncast-slate">
+                  <span>Browse Records</span>
+                  <List size={16} />
+                </div>
+              </div>
+            </Link>
+          </div>
+
+          {/* Features Grid */}
+          <div className="mt-12 rounded-2xl border border-white/60 bg-white p-8 shadow-brand">
+            <h3 className="text-xl font-bold text-spuncast-navy mb-6">System Features</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="flex gap-4">
+                <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-spuncast-red/10 flex items-center justify-center">
+                  <Flame className="w-5 h-5 text-spuncast-red" />
+                </div>
+                <div>
+                  <h4 className="font-bold text-spuncast-navy mb-1">Multi-Stage Tracking</h4>
+                  <p className="text-sm text-spuncast-slate">
+                    Record up to 4 temperature/time cycles per treatment for complete process documentation
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex gap-4">
+                <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-spuncast-navy/10 flex items-center justify-center">
+                  <BarChart3 className="w-5 h-5 text-spuncast-navy" />
+                </div>
+                <div>
+                  <h4 className="font-bold text-spuncast-navy mb-1">Real-Time Analytics</h4>
+                  <p className="text-sm text-spuncast-slate">
+                    Monitor furnace utilization, material performance, and quality trends in real-time
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex gap-4">
+                <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-spuncast-red/10 flex items-center justify-center">
+                  <Plus className="w-5 h-5 text-spuncast-red" />
+                </div>
+                <div>
+                  <h4 className="font-bold text-spuncast-navy mb-1">Quality Metrics</h4>
+                  <p className="text-sm text-spuncast-slate">
+                    Track Brinell hardness numbers (BHN) and TIR measurements for quality assurance
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex gap-4">
+                <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-spuncast-slate/10 flex items-center justify-center">
+                  <List className="w-5 h-5 text-spuncast-slate" />
+                </div>
+                <div>
+                  <h4 className="font-bold text-spuncast-navy mb-1">Resource Tracking</h4>
+                  <p className="text-sm text-spuncast-slate">
+                    Monitor gas usage and cycle times to optimize efficiency and reduce costs
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Load Types Reference */}
+          <div className="mt-8 rounded-2xl border border-white/60 bg-gradient-to-br from-white to-spuncast-sky/20 p-8 shadow-brand">
+            <h3 className="text-xl font-bold text-spuncast-navy mb-4">Supported Load Types</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {[
+                { code: 'WQ', name: 'Water Quench' },
+                { code: 'AC', name: 'Air Cool' },
+                { code: 'F.C.A.', name: 'Furnace Cool Anneal' },
+                { code: 'TEMPER', name: 'Tempering' },
+                { code: 'NORM', name: 'Normalize' },
+                { code: 'AQ', name: 'Air Quench' },
+                { code: 'A.H.', name: 'Anneal Harden' },
+                { code: 'S.R.', name: 'Stress Relief' }
+              ].map(type => (
+                <div key={type.code} className="rounded-lg bg-white border border-gray-200 p-3">
+                  <div className="text-xs font-bold text-spuncast-red mb-1">{type.code}</div>
+                  <div className="text-sm text-spuncast-slate">{type.name}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </main>
+      </div>
+    </>
+  )
+}

--- a/pages/heat-treatment/list.js
+++ b/pages/heat-treatment/list.js
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { ArrowLeft, List, Search } from 'lucide-react'
+import { formatDate, formatLoadType } from '../../lib/heatTreatmentUtils'
+
+export default function HeatTreatmentList() {
+  const [treatments, setTreatments] = useState([])
+  const [filtered, setFiltered] = useState([])
+  const [search, setSearch] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const loadTreatments = async () => {
+      setLoading(true)
+      try {
+        const response = await fetch('/api/heat-treatment?limit=200')
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch heat treatment records')
+        }
+
+        const payload = await response.json()
+        const records = payload.data || []
+
+        setTreatments(records)
+        setFiltered(records)
+      } catch (error) {
+        console.error('Failed to load heat treatments:', error)
+        setTreatments([])
+        setFiltered([])
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadTreatments()
+  }, [])
+
+  useEffect(() => {
+    const term = search.trim().toLowerCase()
+    if (!term) {
+      setFiltered(treatments)
+      return
+    }
+
+    setFiltered(
+      treatments.filter(treatment =>
+        [
+          treatment.heat_number,
+          treatment.part_number,
+          treatment.material_type,
+          treatment.load_type,
+          treatment.job_number
+        ]
+          .filter(Boolean)
+          .some(value => String(value).toLowerCase().includes(term))
+      )
+    )
+  }, [search, treatments])
+
+  return (
+    <>
+      <Head>
+        <title>Heat Treatment Records | Manufacturing System</title>
+      </Head>
+
+      <div className="min-h-screen bg-gradient-to-br from-spuncast-sky via-white to-spuncast-sky/50">
+        <header className="bg-white/95 backdrop-blur border-b border-spuncast-navy/10 shadow-sm">
+          <div className="max-w-7xl mx-auto px-4 py-5">
+            <div className="flex items-center gap-4">
+              <Link href="/heat-treatment" className="text-spuncast-navy hover:text-spuncast-navyDark transition">
+                <ArrowLeft size={24} />
+              </Link>
+              <div className="flex items-center gap-4">
+                <List className="h-10 w-10 text-spuncast-slate" />
+                <div>
+                  <p className="text-sm uppercase tracking-[0.3em] text-spuncast-slate font-semibold">Records</p>
+                  <h1 className="text-2xl font-bold text-spuncast-navy">Heat Treatment History</h1>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <main className="mx-auto max-w-7xl px-4 py-8">
+          <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-xl font-bold text-spuncast-navy">All Treatment Records</h2>
+              <p className="text-sm text-spuncast-slate">
+                Browse the most recent heat treatment cycles and export data for reporting
+              </p>
+            </div>
+            <div className="flex items-center gap-2 rounded-full border border-gray-300 bg-white px-4 py-2 shadow-sm">
+              <Search className="h-4 w-4 text-gray-400" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search by heat number, part, material, or load type"
+                className="w-64 bg-transparent text-sm focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="overflow-x-auto rounded-2xl border border-white/60 bg-white shadow-brand">
+            <table className="w-full min-w-[800px]">
+              <thead>
+                <tr className="bg-spuncast-sky/40 text-left text-xs font-semibold uppercase tracking-wide text-spuncast-slate">
+                  <th className="p-3">Date</th>
+                  <th className="p-3">Heat #</th>
+                  <th className="p-3">Furnace</th>
+                  <th className="p-3">Load</th>
+                  <th className="p-3">Load Type</th>
+                  <th className="p-3">Part #</th>
+                  <th className="p-3">Material</th>
+                  <th className="p-3">Cast Weight</th>
+                  <th className="p-3">Hot BHN</th>
+                  <th className="p-3">Cold BHN</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((treatment) => (
+                  <tr key={treatment.id} className="border-t border-gray-100 text-sm hover:bg-spuncast-sky/30">
+                    <td className="p-3 text-spuncast-slate">{formatDate(treatment.day_finished)}</td>
+                    <td className="p-3 font-semibold text-spuncast-navy">{treatment.heat_number}</td>
+                    <td className="p-3">{treatment.furnace_number || '-'}</td>
+                    <td className="p-3">{treatment.load_number || '-'}</td>
+                    <td className="p-3">
+                      <span className="inline-flex items-center rounded-full bg-spuncast-navy/10 px-2.5 py-1 text-xs font-semibold text-spuncast-navy">
+                        {formatLoadType(treatment.load_type) || 'N/A'}
+                      </span>
+                    </td>
+                    <td className="p-3">{treatment.part_number || '-'}</td>
+                    <td className="p-3">{treatment.material_type || '-'}</td>
+                    <td className="p-3">{treatment.cast_weight ? `${treatment.cast_weight} lbs` : '-'}</td>
+                    <td className="p-3 text-spuncast-red font-semibold">{treatment.hot_end_bhn || '-'}</td>
+                    <td className="p-3 text-spuncast-red font-semibold">{treatment.cold_end_bhn || '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {!loading && filtered.length === 0 && (
+              <div className="p-8 text-center text-sm text-spuncast-slate">
+                No heat treatments found for your search.
+              </div>
+            )}
+
+            {loading && (
+              <div className="p-8 text-center text-sm text-spuncast-slate">
+                Loading heat treatment records...
+              </div>
+            )}
+          </div>
+        </main>
+      </div>
+    </>
+  )
+}

--- a/pages/heat-treatment/new.js
+++ b/pages/heat-treatment/new.js
@@ -1,0 +1,48 @@
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import Link from 'next/link'
+import HeatTreatmentForm from '../../components/HeatTreatmentForm'
+import { ArrowLeft, Flame } from 'lucide-react'
+
+export default function NewHeatTreatment() {
+  const router = useRouter()
+
+  const handleSuccess = (data) => {
+    // Redirect to dashboard after 2 seconds
+    setTimeout(() => {
+      router.push('/heat-treatment/dashboard')
+    }, 2000)
+  }
+
+  return (
+    <>
+      <Head>
+        <title>New Heat Treatment Entry | Manufacturing System</title>
+      </Head>
+
+      <div className="min-h-screen bg-gradient-to-br from-spuncast-sky via-white to-spuncast-sky/50">
+        {/* Header */}
+        <header className="bg-white/95 backdrop-blur border-b border-spuncast-navy/10 shadow-sm">
+          <div className="max-w-7xl mx-auto px-4 py-5">
+            <div className="flex items-center gap-4">
+              <Link href="/heat-treatment" className="text-spuncast-navy hover:text-spuncast-navyDark transition">
+                <ArrowLeft size={24} />
+              </Link>
+              <div className="flex items-center gap-4">
+                <Flame className="h-10 w-10 text-spuncast-red" />
+                <div>
+                  <p className="text-sm uppercase tracking-[0.3em] text-spuncast-red font-semibold">Data Entry</p>
+                  <h1 className="text-2xl font-bold text-spuncast-navy">New Heat Treatment Entry</h1>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <main className="mx-auto max-w-5xl px-4 py-8">
+          <HeatTreatmentForm onSuccess={handleSuccess} />
+        </main>
+      </div>
+    </>
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,6 @@
 import ToolChangeForm from '../components/ToolChangeForm'
 import Link from 'next/link'
-import { BarChart3, Plus, QrCode, Ruler } from 'lucide-react'
+import { BarChart3, Plus, QrCode, Ruler, Flame } from 'lucide-react'
 
 export default function Home() {
   return (
@@ -47,6 +47,15 @@ export default function Home() {
                   <QrCode size={18} />
                 </span>
                 <span>QR Generator</span>
+              </Link>
+              <Link
+                href="/heat-treatment"
+                className="group inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-spuncast-navy to-spuncast-red px-5 py-2.5 text-white shadow-brand transition hover:from-spuncast-navyDark hover:to-spuncast-redDark"
+              >
+                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-white">
+                  <Flame size={18} />
+                </span>
+                <span>Heat Treatment</span>
               </Link>
             </nav>
           </div>
@@ -98,6 +107,18 @@ export default function Home() {
               <div>
                 <h3 className="text-xl font-semibold">Generate QR Codes</h3>
                 <p className="text-sm text-white/80">Produce equipment QR codes that match Spuncast branding.</p>
+              </div>
+            </div>
+          </Link>
+
+          <Link href="/heat-treatment" className="group rounded-2xl bg-gradient-to-br from-spuncast-red to-spuncast-navy p-6 text-white shadow-brand transition-transform hover:-translate-y-1">
+            <div className="flex items-start gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white">
+                <Flame size={28} />
+              </div>
+              <div>
+                <h3 className="text-xl font-semibold">Heat Treatment Management</h3>
+                <p className="text-sm text-white/80">Record cycles, view analytics, and monitor furnace utilization.</p>
               </div>
             </div>
           </Link>


### PR DESCRIPTION
## Summary
- switch the heat treatment form and dashboards to post and fetch through the Next.js API so the service role handles database access without requiring Supabase login
- extend the heat treatment stats API to surface recent treatments and reuse its data on the dashboard widgets
- update the record list to consume the open API responses, keeping browsing unrestricted during the trial

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db3f6596a8832abbdac11b1bad612a