### PR TITLE
Normalize pour report time parsing

### DIFF
--- a/lib/pourReportService.js
+++ b/lib/pourReportService.js
@@ -62,6 +62,47 @@ const normalizeBoolean = (value) => {
 const removeUndefined = (object) =>
   Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined))
 
+const cleanTimeFormat = (timeStr) => {
+  if (timeStr === undefined || timeStr === null) return null
+
+  const str = String(timeStr).trim()
+  if (str === '' || str === '0') return null
+
+  if (/AM|PM/i.test(str)) {
+    const match = str.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i)
+    if (!match) return null
+
+    let [, hours, minutes, period] = match
+    hours = parseInt(hours, 10)
+    minutes = parseInt(minutes, 10)
+
+    if (period.toUpperCase() === 'PM' && hours !== 12) {
+      hours += 12
+    } else if (period.toUpperCase() === 'AM' && hours === 12) {
+      hours = 0
+    }
+
+    if (hours >= 24 || hours < 0 || minutes >= 60 || minutes < 0) {
+      return null
+    }
+
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:00`
+  }
+
+  const match = str.match(/(\d{1,2}):(\d{2})/)
+  if (!match) return null
+
+  const [, hours, minutes] = match
+  const h = parseInt(hours, 10)
+  const m = parseInt(minutes, 10)
+
+  if (h >= 24 || h < 0 || m >= 60 || m < 0) {
+    return null
+  }
+
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:00`
+}
+
 const buildPourReportPayload = (data) =>
   removeUndefined({
     heat_number: toOptionalString(data.heat_number),
@@ -79,8 +120,8 @@ const buildPourReportPayload = (data) =>
     power_percent: parseOptionalFloat(data.power_percent),
     new_lining: normalizeBoolean(data.new_lining),
     ladle_number: parseOptionalInteger(data.ladle_number),
-    start_time: toOptionalString(data.start_time),
-    tap_time: toOptionalString(data.tap_time),
+    start_time: cleanTimeFormat(data.start_time),
+    tap_time: cleanTimeFormat(data.tap_time),
     tap_temp: parseOptionalInteger(data.tap_temp),
     pour_temperature: parseOptionalInteger(data.pour_temperature),
     liquid_canon: parseOptionalFloat(data.liquid_canon),

--- a/pages/api/upload/pour-reports.js
+++ b/pages/api/upload/pour-reports.js
@@ -8,6 +8,50 @@ export const config = {
   },
 }
 
+const cleanTimeFormat = (timeStr) => {
+  if (timeStr === undefined || timeStr === null) return null
+
+  const str = String(timeStr).trim()
+  if (str === '' || str === '0') return null
+
+  // Handle invalid formats like "15:50 AM"
+
+  // If it has AM/PM, parse and convert to 24-hour
+  if (/AM|PM/i.test(str)) {
+    const match = str.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i)
+    if (!match) return null
+
+    let [, hours, minutes, period] = match
+    hours = parseInt(hours, 10)
+    minutes = parseInt(minutes, 10)
+
+    if (period.toUpperCase() === 'PM' && hours !== 12) {
+      hours += 12
+    } else if (period.toUpperCase() === 'AM' && hours === 12) {
+      hours = 0
+    }
+
+    if (hours >= 24 || hours < 0 || minutes >= 60 || minutes < 0) {
+      return null
+    }
+
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:00`
+  }
+
+  const match = str.match(/(\d{1,2}):(\d{2})/)
+  if (!match) return null
+
+  const [, hours, minutes] = match
+  const h = parseInt(hours, 10)
+  const m = parseInt(minutes, 10)
+
+  if (h >= 24 || h < 0 || m >= 60 || m < 0) {
+    return null
+  }
+
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:00`
+}
+
 const parseDate = (dateStr) => {
   if (!dateStr) return null
 
@@ -56,8 +100,8 @@ const transformPourReportRow = (row) => {
     power_percent: parseNumber(row.power_percent),
     new_lining: (row.new_lining || '').toUpperCase() === 'Y',
     ladle_number: parseInteger(row.ladle_number),
-    start_time: row.start_time || null,
-    tap_time: row.tap_time || null,
+    start_time: cleanTimeFormat(row.start_time),
+    tap_time: cleanTimeFormat(row.tap_time),
     tap_temp: parseInteger(row.tap_temp),
     pour_temperature: parseInteger(row.pour_tempurature || row.pour_temperature),
     liquid_canon: parseNumber(row.liquid_canon),

--- a/pages/bulk-upload.js
+++ b/pages/bulk-upload.js
@@ -57,6 +57,47 @@ export default function BulkUpload() {
     return data
   }
 
+  const cleanTimeFormat = (timeStr) => {
+    if (timeStr === undefined || timeStr === null) return null
+
+    const str = String(timeStr).trim()
+    if (str === '' || str === '0') return null
+
+    if (/AM|PM/i.test(str)) {
+      const match = str.match(/(\d{1,2}):(\d{2})\s*(AM|PM)/i)
+      if (!match) return null
+
+      let [, hours, minutes, period] = match
+      hours = parseInt(hours, 10)
+      minutes = parseInt(minutes, 10)
+
+      if (period.toUpperCase() === 'PM' && hours !== 12) {
+        hours += 12
+      } else if (period.toUpperCase() === 'AM' && hours === 12) {
+        hours = 0
+      }
+
+      if (hours >= 24 || hours < 0 || minutes >= 60 || minutes < 0) {
+        return null
+      }
+
+      return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:00`
+    }
+
+    const match = str.match(/(\d{1,2}):(\d{2})/)
+    if (!match) return null
+
+    const [, hours, minutes] = match
+    const h = parseInt(hours, 10)
+    const m = parseInt(minutes, 10)
+
+    if (h >= 24 || h < 0 || m >= 60 || m < 0) {
+      return null
+    }
+
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:00`
+  }
+
   const parseDate = (dateStr) => {
     if (!dateStr) return null
 
@@ -105,8 +146,8 @@ export default function BulkUpload() {
       power_percent: parseNumber(row.power_percent),
       new_lining: (row.new_lining || '').toUpperCase() === 'Y',
       ladle_number: parseInteger(row.ladle_number),
-      start_time: row.start_time || null,
-      tap_time: row.tap_time || null,
+      start_time: cleanTimeFormat(row.start_time),
+      tap_time: cleanTimeFormat(row.tap_time),
       tap_temp: parseInteger(row.tap_temp),
       pour_temperature: parseInteger(row.pour_tempurature || row.pour_temperature),
       liquid_canon: parseNumber(row.liquid_canon),


### PR DESCRIPTION
## Summary
- add a reusable `cleanTimeFormat` helper that normalizes time strings and filters invalid values
- ensure pour report uploads and payload construction use the normalized time format

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0a544c220832aa9f23076940b79b5