### PR TITLE
Deduplicate pour report imports before Supabase writes

### DIFF
--- a/lib/pourReportService.js
+++ b/lib/pourReportService.js
@@ -175,16 +175,46 @@ export class PourReportService {
   }
 
   static async bulkImportPourReports(reports, { skipDuplicates = true } = {}) {
+    let duplicatesSkipped = 0
+
     try {
-      const normalizedReports = (reports ?? []).map((report) => buildPourReportPayload(report))
+      const normalizedReports = (reports ?? []).map((report, index) => ({
+        payload: buildPourReportPayload(report),
+        index,
+      }))
 
       if (normalizedReports.length === 0) {
-        return { success: true, data: [], count: 0 }
+        return { success: true, data: [], count: 0, duplicatesSkipped: 0 }
+      }
+
+      const dedupedMap = new Map()
+
+      normalizedReports.forEach(({ payload, index }) => {
+        const key = payload.full_heat_number
+        if (key) {
+          if (dedupedMap.has(key)) {
+            duplicatesSkipped += 1
+            console.warn(
+              `Duplicate full_heat_number ${key} encountered during bulk import. Keeping occurrence at index ${index}.`
+            )
+          }
+          dedupedMap.set(key, { payload, index })
+        } else {
+          dedupedMap.set(`no_key_${index}`, { payload, index })
+        }
+      })
+
+      const uniqueReports = Array.from(dedupedMap.values())
+        .sort((a, b) => a.index - b.index)
+        .map(({ payload }) => payload)
+
+      if (uniqueReports.length === 0) {
+        return { success: true, data: [], count: 0, duplicatesSkipped }
       }
 
       const method = skipDuplicates ? 'upsert' : 'insert'
       const query = supabase
-        .from('pour_reports')[method](normalizedReports, {
+        .from('pour_reports')[method](uniqueReports, {
           onConflict: skipDuplicates ? 'full_heat_number' : undefined,
           ignoreDuplicates: skipDuplicates || undefined
         })
@@ -193,10 +223,10 @@ export class PourReportService {
       const { data, error } = await query
 
       if (error) throw error
-      return { success: true, data, count: data?.length ?? 0 }
+      return { success: true, data, count: data?.length ?? 0, duplicatesSkipped }
     } catch (error) {
       console.error('Error bulk importing pour reports:', error)
-      return { success: false, error: error.message }
+      return { success: false, error: error.message, duplicatesSkipped }
     }
   }
 


### PR DESCRIPTION
## Summary
- deduplicate pour report uploads in the API handler so only unique full heat numbers are batched
- surface skipped duplicate counts in the upload response for improved UI messaging
- extend the same deduplication and logging to the bulk import service API response

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0a85e80b4832a8342bb1d1cedd079